### PR TITLE
Convert to CLI script with GeoParquet capabilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+.DS_Store
+stac/
+stac-parquet/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -1,36 +1,42 @@
-# stac
-This repo serves two functions: 
+# Overture STAC
+
+This repo serves two functions:
+
 1) to generate STAC Catalogs for a single overture release.
 2) To generate download manifests for the explore site.
 
-## To generate a STAC Catalog: 
+## To generate a STAC Catalog:
 
-Modify the gen-data-release-stac.py so that the release_version is correct: 
+The required arguments are `--release=<RELEASE>` and `--schema=<VERSION>` (without the leading v), for example:
 
-`release_version = "2025-04-23.0"`
+The script will trawl through the public release folder and emit the STAC catalog contents in the `stac` directory.
 
-Then execute the script: 
-`python3 ./gen-data-release-stac.py`
+Optionally, specify `--output=<PATH>` to write somewhere other than `stac`, and `--parquet=<PATH>` will write a per-type StacGeoParquet file at that path.
 
-The script will trawl through the public release folder and emit the STAC catalog contents in the `build` directory. 
+Example:
+```bash
+python3 gen-data-release-stac.py --release=2025-05-21.0 --schema=1.9.0 --output=stac --parquet=stac-parquet
+```
+Writes a complete STAC catalog to the `stac` directory, and a per-type StacGeoParquet file to the the `stac-parquet` directory.
 
-## To generate the explore site manifest: 
-Same as above, but instead you will modify / run the `gen-explore-site-manifest.py` script instead. 
 
-The manifest is stored in a file called `{release_version}.json` when done. 
+## To generate the explore site manifest:
+Same as above, but instead you will modify / run the `gen-explore-site-manifest.py` script instead.
+
+The manifest is stored in a file called `{release_version}.json` when done.
 
 
 
 ## Virtual Environment
-To enter the venv: 
+To enter the venv:
 
-cd to the base dir. 
+cd to the base dir.
 > virtualenv -p python3 .
 > source   bin/activate
-> python3 ./gen-manifest.py 
+> python3 ./gen-manifest.py
 
-Then pip install any modules you're missing. 
+Then pip install any modules you're missing.
 
-To exit the venv: 
+To exit the venv:
 
 > deactivate

--- a/gen-bbox-per-parquet.py
+++ b/gen-bbox-per-parquet.py
@@ -1,44 +1,44 @@
+import json
+
 import pyarrow as pa
 import pyarrow.compute as pc
 import pyarrow.dataset as ds
 import pyarrow.fs as fs
-import os
-import json
 
 release_version = "2024-06-13-beta.1"
 theme_path = "/theme=buildings"
 type_path = "/type=building"
 
 file_loc = "overturemaps-us-west-2/release/" + release_version + theme_path + type_path
-print ('examining ' + file_loc + ' metadata.');
+print("examining " + file_loc + " metadata.")
 
 ### Look in a specific release to obtain the themes themselves
 filesystem = fs.S3FileSystem(anonymous=True, region="us-west-2")
 
-file_selector = fs.FileSelector(file_loc);
+file_selector = fs.FileSelector(file_loc)
 
-file_info = filesystem.get_file_info(file_selector);
+file_info = filesystem.get_file_info(file_selector)
 
 # dataset = ds.dataset(
 #     path, filesystem=fs.S3FileSystem(anonymous=True, region="us-west-2")
 # )
 
 dataset = ds.dataset(
-        file_loc, filesystem=fs.S3FileSystem(anonymous=True, region="us-west-2")
-    )
+    file_loc, filesystem=fs.S3FileSystem(anonymous=True, region="us-west-2")
+)
 
-metadata = dataset.schema.metadata[b'geo']
+metadata = dataset.schema.metadata[b"geo"]
 
-meta_str = metadata.decode('utf-8');
+meta_str = metadata.decode("utf-8")
 
 metadata_obj = json.loads(meta_str)
 
-bbox_string = json.dumps(metadata_obj['columns']['geometry']['bbox'])
-version = metadata_obj['version'];
+bbox_string = json.dumps(metadata_obj["columns"]["geometry"]["bbox"])
+version = metadata_obj["version"]
 col_names = dataset.schema.names
-# Do we need to include/serialize the column formats? 
+# Do we need to include/serialize the column formats?
 # col_formats = dataset.schema.types
-print ('bbox: ' + bbox_string)
+print("bbox: " + bbox_string)
 
 
 # example value: b'{"version":"1.0.0","primary_column":"geometry","columns":{"geometry":{"encoding":"WKB","geometry_types":["Polygon","MultiPolygon"],"bbox":[-179.9999966,-83.6500139,-2.8229824,-0.00313771110055319]}}}'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pystac>=1.8.4
+pyarrow>=14.0.1
+stac-geoparquet>=0.7.0


### PR DESCRIPTION
Adds Stac GeoParquet and command line arguments to control generation. 

This is hopefully a minimum-viable-product for full STAC integration.

TODO: Generate the single manifest JSON file _from_ the STAC GeoParquet with a DuckDB query?