### PR TITLE
[CHORE] Add maintainers, keywords, and URLs to pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,15 +5,25 @@ description = "Generate STAC catalogs for Overture Maps Releases"
 authors = [
     {name = "Overture Maps Foundation"}
 ]
+maintainers = [
+    {name = "Adam Lastowka", email = "adam@overturemaps.org"},
+    {name = "Jennings Anderson", email = "jenningsa@meta.com"},
+]
 readme = "README.md"
 license = {text = "MIT"}
 requires-python = ">=3.9"
+keywords = ["stac", "catalog", "overture", "geospatial", "metadata", "maps"]
 dependencies = [
     "pystac>=1.8.4",
     "pyarrow>=14.0.1",
     "stac-geoparquet>=0.7.0",
     "pyyaml>=6.0.2",
 ]
+
+[project.urls]
+Homepage = "https://overturemaps.org"
+Source = "https://github.com/OvertureMaps/stac"
+Issues = "https://github.com/OvertureMaps/stac/issues"
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
Enhance pyproject.toml package metadata by adding a maintainers list (names and emails), a keywords array for discoverability, and project.urls entries (Homepage, Source, Issues). This improves contact information and project links for package consumers and registries; no dependency changes were made.

Partially resolves https://github.com/OvertureMaps/ops-team/issues/258