### PR TITLE
[FEATURE](ci) Auto post staging deploy comments & cleanup

### DIFF
--- a/.github/workflows/staging.yaml
+++ b/.github/workflows/staging.yaml
@@ -49,6 +49,7 @@ jobs:
     name: Deploy
     runs-on: ubuntu-latest
     needs: build
+    if: github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       id-token: write      # required for OIDC token exchange with AWS
       actions: read        # required for actions/download-artifact

--- a/.github/workflows/staging.yaml
+++ b/.github/workflows/staging.yaml
@@ -50,8 +50,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     permissions:
-      id-token: write   # required for OIDC token exchange with AWS
-      actions: read     # required for actions/download-artifact
+      id-token: write      # required for OIDC token exchange with AWS
+      actions: read        # required for actions/download-artifact
+      pull-requests: write # for posting staging preview PR comments
     environment:
       name: staging
       url: https://staging.overturemaps.org/${{ github.event.repository.name }}/pr/${{ github.event.number }}/catalog.json
@@ -80,3 +81,26 @@ jobs:
         env:
           GITHUB_EVENT_REPOSITORY_NAME: ${{ github.event.repository.name }}
           GITHUB_EVENT_NUMBER: ${{ github.event.number }}
+
+      - name: Gather metadata for PR comment
+        id: deploy-metadata
+        run: |
+          echo "time=$(date -u +'%b %d, %Y %H:%M UTC')" >> $GITHUB_OUTPUT
+          echo "short-sha=${PR_HEAD_SHA:0:7}" >> $GITHUB_OUTPUT
+        env:
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+
+      - name: Comment on PR
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
+        with:
+          message: |
+            ## 🗺️ OMF STAC preview is live!
+
+            |                |                                                                           |
+            |----------------|---------------------------------------------------------------------------|
+            | 📦 **Catalog** | https://staging.overturemaps.org/${{ github.event.repository.name }}/pr/${{ github.event.number }}/catalog.json |
+            | 🕐 **Updated** | ${{ steps.deploy-metadata.outputs.time }}                                 |
+            | 📝 **Commit**  | [${{ steps.deploy-metadata.outputs.short-sha }}](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.event.pull_request.head.sha }}) |
+
+            > [!NOTE]
+            > ♻️ This preview updates automatically with each push to this PR.

--- a/.github/workflows/staging.yaml
+++ b/.github/workflows/staging.yaml
@@ -49,6 +49,7 @@ jobs:
     name: Deploy
     runs-on: ubuntu-latest
     needs: build
+    if: github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       id-token: write   # required for OIDC token exchange with AWS
       actions: read     # required for actions/download-artifact

--- a/.github/workflows/staging_cleanup.yaml
+++ b/.github/workflows/staging_cleanup.yaml
@@ -1,0 +1,50 @@
+---
+name: Staging Cleanup
+run-name: ♻️ Clean up staging preview for PR #${{ github.event.number }}
+
+on:
+  pull_request:
+    types: [closed]
+
+concurrency:
+  group: staging-cleanup-${{ github.event.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  cleanup:
+    name: Cleanup
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # for AWS OIDC authentication
+    env:
+      AWS_ROLE_ARN: arn:aws:iam::763944545891:role/pages-staging-oidc-overturemaps
+      AWS_REGION: us-west-2
+
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
+        with:
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      # No flags to ignore "not found" errors, so we use "|| true" to prevent failure if the path doesn't exist
+      - name: Delete from S3
+        run: |
+          aws s3 rm --recursive \
+            s3://overture-managed-staging-usw2/gh-pages/${GITHUB_EVENT_REPOSITORY_NAME}/pr/${GITHUB_EVENT_NUMBER}/ || true
+        env:
+          GITHUB_EVENT_REPOSITORY_NAME: ${{ github.event.repository.name }}
+          GITHUB_EVENT_NUMBER: ${{ github.event.number }}
+
+      - name: Bust the cache
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id E1KP2IN0H2RGGT \
+            --paths "/${GITHUB_EVENT_REPOSITORY_NAME}/pr/${GITHUB_EVENT_NUMBER}/*" || true
+        env:
+          GITHUB_EVENT_REPOSITORY_NAME: ${{ github.event.repository.name }}
+          GITHUB_EVENT_NUMBER: ${{ github.event.number }}


### PR DESCRIPTION
## Changes

* Update staging workflow to post a sticky PR comment with preview URL and metadata (time and short commit SHA); add pull-requests: write permission and a step to gather metadata. 
* Add a new Staging Cleanup workflow triggered on PR close that assumes an AWS OIDC role, deletes the PR preview from S3, and creates a CloudFront invalidation to remove cached preview paths.

## Testing

See the comment below to test the new feature in this PR: https://github.com/OvertureMaps/stac/pull/44#issuecomment-4336921855