### PR TITLE
ci: guard staging deploy job against fork PRs

### DIFF
--- a/.github/workflows/staging.yaml
+++ b/.github/workflows/staging.yaml
@@ -49,6 +49,7 @@ jobs:
     name: Deploy
     runs-on: ubuntu-latest
     needs: build
+    if: github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       id-token: write   # required for OIDC token exchange with AWS
       actions: read     # required for actions/download-artifact


### PR DESCRIPTION
## Summary

- The `deploy` job assumes an AWS OIDC role (`id-token: write`) but had no condition preventing it from running on PRs from forks
- Fork PRs can't receive the OIDC token, so the job would fail with a confusing error for external contributors
- Applies the same one-line guard already used in `staging_cleanup.yaml`

```yaml
if: github.event.pull_request.head.repo.full_name == github.repository
```

Fork PRs now skip `deploy` cleanly (shown as skipped, not failed) while `build` continues to run normally so contributors still get CI feedback.

## Test plan

- [ ] Open a PR from a fork — verify `build` passes and `deploy` is skipped
- [ ] Open a PR from within the repo — verify both `build` and `deploy` run as before