### PR TITLE
[BUG] Use 3 fragments in debug mode to pass bbox validation

### DIFF
--- a/src/overture_stac/overture_stac.py
+++ b/src/overture_stac/overture_stac.py
@@ -102,7 +102,7 @@ def process_theme_worker(
         # Get all fragments
         all_fragments = list(type_dataset.get_fragments())
         if debug:
-            all_fragments = all_fragments[:2]
+            all_fragments = all_fragments[:3]
 
         total_fragments: int = len(all_fragments)
 


### PR DESCRIPTION
**Closes #48**

### Problem

Debug mode processes 2 fragments per type, producing exactly 2 bboxes in `extent.spatial.bbox`. The STAC `v1.1.0` JSON Schema requires either 1 or 3+.

```json
"bbox": {
  "title": "Spatial extents",
  "type": "array",
  "oneOf": [
    {
      "minItems": 1,
      "maxItems": 1
    },
    {
      "minItems": 3
    }
  ],
  "items": {
    "title": "Spatial extent",
    "type": "array",
    "oneOf": [
      {
        "minItems": 4,
        "maxItems": 4
      },
      {
        "minItems": 6,
        "maxItems": 6
      }
    ],
    "items": {
      "type": "number"
    }
  }
}
```

### Fix

Change debug fragment limit from 2 to 3. CI now produces 3 bboxes, satisfying `minItems: 3`.
