### PR TITLE
[CHORE](ci) Setup publishing to PyPI on release

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -33,6 +33,7 @@ jobs:
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           enable-cache: true
+          python-version-file: "pyproject.toml"
 
       - name: Build package
         run: uv build

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,68 @@
+---
+# Publishes the overture-stac package in two scenarios:
+#   1. Release (production): triggered when a GitHub Release is published → publishes to PyPI. Ensure pyproject.toml has had a version bump that matches the release version.
+#   2. Dry-run: triggered manually via workflow_dispatch → publishes to Test PyPI to verify
+#      the build and publish pipeline end-to-end without affecting the production package index.
+# Uses OIDC trusted publishing — no API token required.
+name: Publish overture-stac
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read # required to checkout the code from the repo
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: true
+
+      - name: Build package
+        run: uv build
+
+      - name: Upload dist artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    name: Target '${{ github.event_name == 'workflow_dispatch' && 'Test PyPI' || 'PyPI' }}'
+    needs: build
+    runs-on: ubuntu-latest
+    environment: ${{ github.event_name == 'workflow_dispatch' && 'test-pypi' || 'pypi' }}
+    env:
+      TEST_PYPI_URL: https://test.pypi.org/legacy/
+    permissions:
+      id-token: write # OIDC — required for PyPI trusted publishing
+    steps:
+      - name: Download dist artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        with:
+          repository-url: ${{ github.event_name == 'workflow_dispatch' && env.TEST_PYPI_URL || '' }}
+          skip-existing: ${{ github.event_name == 'workflow_dispatch' }}
+          attestations: true
+          verbose: false

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![CI](https://github.com/OvertureMaps/stac/actions/workflows/ci.yaml/badge.svg)](https://github.com/OvertureMaps/stac/actions/workflows/ci.yaml)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
+![PyPI - Version](https://img.shields.io/pypi/v/overture-stac)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 Generate STAC catalogs for all public Overture Maps releases.

--- a/README.md
+++ b/README.md
@@ -31,3 +31,10 @@ gen-stac --output ./releases --workers 8
 ```bash
 uv run ruff format . && uv run ruff check . && uv run pytest
 ```
+
+## Release
+
+Once a GitHub Release has been created (and the pyproject.toml contains a version bump),
+`publish-pypi.yml` is triggered to publish to PyPI.
+
+Manual dispatches of that workflow will publish to https://test.pypi.org/project/overture-stac/ for debugging and validation.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Overture STAC
 
 [![CI](https://github.com/OvertureMaps/stac/actions/workflows/ci.yaml/badge.svg)](https://github.com/OvertureMaps/stac/actions/workflows/ci.yaml)
-[![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/downloads/)
+[![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 Generate STAC catalogs for all public Overture Maps releases.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "overture-stac"
-version = "1.0.7"
+version = "1.0.6"
 description = "Generate STAC catalogs for Overture Maps Releases"
 authors = [
     {name = "Overture Maps Foundation"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "overture-stac"
-version = "1.0.6"
+version = "1.0.7"
 description = "Generate STAC catalogs for Overture Maps Releases"
 authors = [
     {name = "Overture Maps Foundation"}
@@ -40,6 +40,14 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/overture_stac"]
+
+[tool.hatch.build.targets.sdist]
+exclude = [
+    "/.github",
+    "/.gitignore",
+    "/CODEOWNERS",
+    "/uv.lock",
+]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
## Changes

Instead of it being a manual, local step to publish new versions of `overture-stac` to the internal CodeArtifactory, we will now begin publishing the package to PyPI publicly for every GitHub release created.

Since the repository and license are already open and permissive, this reduces the toil to upkeep this package in addition to making it more discoverable on our main overturemaps PyPI account.

## Testing

I did some light testing of the setup via https://test.pypi.org/project/overture-stac/ for version 1.0.6

Once a release is created for version 1.0.7, it should automatically publish the package to the main site @ https://pypi.org/project/overture-stac/.

This is the exact same approach/workflow we use for `overture-py` to publish to PyPI.