### PR TITLE
[BUG] Fix license field validation failures

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -139,4 +139,3 @@ jobs:
       - uses: lowlydba/are-we-good@bb8ee9e793e4233fac1992bb880e2a28bed7f42f # v1.0.3
         with:
           jobs: ${{ toJSON(needs) }}
-          allowed-to-fail: "stac-validate" #TODO: Remove after issues #48, 49, 50, 51 are resolved and this passes

--- a/src/overture_stac/overture_stac.py
+++ b/src/overture_stac/overture_stac.py
@@ -12,19 +12,20 @@ import stac_geoparquet
 
 TYPE_LICENSE_MAP: dict[str, str] = {
     "bathymetry": "CC0-1.0",
-    "land_cover": "	CC-BY-4.0",
+    "land_cover": "CC-BY-4.0",
     "infrastructure": "ODbL-1.0",
     "land": "ODbL-1.0",
     "land_use": "ODbL-1.0",
     "water": "ODbL-1.0",
     "building": "ODbL-1.0",
+    "building_part": "ODbL-1.0",
     "division": "ODbL-1.0",
     "division_area": "ODbL-1.0",
     "division_boundary": "ODbL-1.0",
     "segment": "ODbL-1.0",
     "connector": "ODbL-1.0",
-    "place": "CDLA-Permissive-2.0, Apache 2.0, CC0 1.0.",
-    "address": "Multiple Open Licenses",
+    "place": "other",
+    "address": "other",
 }
 
 
@@ -219,6 +220,16 @@ def process_theme_worker(
             ),
             license=TYPE_LICENSE_MAP.get(type_name),
         )
+
+        # Licenses with multiple SPDXs must be marked as "other" and include a link to the license details
+        if TYPE_LICENSE_MAP.get(type_name) == "other":
+            type_collection.add_link(
+                pystac.Link(
+                    rel="license",
+                    target="https://docs.overturemaps.org/attribution/",
+                    title="Overture Maps Attribution and Licensing",
+                )
+            )
 
         type_collection.add_items(local_type_collections[type_name])
 


### PR DESCRIPTION
Fixes four `license` field failures causing [CI STAC validation](https://github.com/OvertureMaps/stac/actions/runs/25791088724/job/75756532491) to fail.

- Remove leading tab from `land_cover` value
- Add missing `building_part` → `ODbL-1.0`
- Change `place` and `address` to `"other"` (multi-license, no single SPDX ID) with a `rel=license` link per [STAC spec](https://github.com/radiantearth/stac-spec/blob/master/collection-spec/collection-spec.md)
