### PR TITLE
[ENHANCEMENT] Add title fields to STAC catalogs/collections

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "overture-stac"
-version = "1.0.7"
+version = "1.0.8"
 description = "Generate STAC catalogs for Overture Maps Releases"
 authors = [
     {name = "Overture Maps Foundation"}

--- a/src/overture_stac/cli.py
+++ b/src/overture_stac/cli.py
@@ -55,6 +55,7 @@ def main():
 
     overture_releases_catalog = pystac.Catalog(
         id="Overture Releases",
+        title="Overture Releases",
         description="All Overture Releases",
     )
 

--- a/src/overture_stac/overture_stac.py
+++ b/src/overture_stac/overture_stac.py
@@ -65,7 +65,9 @@ def process_theme_worker(
     logger.info(f"Processing Theme: {theme_name}")
 
     theme_catalog = pystac.Catalog(
-        id=theme_name, description=f"Overture's {theme_name} theme"
+        id=theme_name,
+        title=theme_name,
+        description=f"Overture's {theme_name} theme",
     )
 
     # Add PMTiles link if available for this theme
@@ -211,6 +213,7 @@ def process_theme_worker(
         # Create type collection
         type_collection = pystac.Collection(
             id=type_name,
+            title=type_name,
             description=f"Overture's {type_name} collection",
             extent=pystac.Extent(
                 spatial=pystac.SpatialExtent(
@@ -252,7 +255,7 @@ def process_theme_worker(
         if not debug:
             type_collection.extra_fields = {"features": total_row_count}
 
-        theme_catalog.add_child(type_collection)
+        theme_catalog.add_child(type_collection, title=type_name)
 
     return (theme_catalog, local_manifest_items, local_type_collections, theme_name)
 

--- a/tests/setup_test_catalog.py
+++ b/tests/setup_test_catalog.py
@@ -112,6 +112,7 @@ def build_test_catalog(
     # Create root catalog to match CLI structure
     root_catalog = pystac.Catalog(
         id="Overture Releases",
+        title="Overture Releases",
         description="All Overture Releases (Test)",
     )
 

--- a/tests/test_process_theme_worker.py
+++ b/tests/test_process_theme_worker.py
@@ -220,7 +220,6 @@ class TestProcessThemeWorker:
         pmtiles_links = [link for link in theme_catalog.links if link.rel == "pmtiles"]
         assert len(pmtiles_links) == 1
 
-
     @patch("overture_stac.overture_stac.ds")
     @patch("overture_stac.overture_stac.fs")
     def test_child_links_have_titles(self, mock_fs, mock_ds):
@@ -266,6 +265,7 @@ class TestProcessThemeWorker:
         collections = list(theme_catalog.get_children())
         assert collections[0].title is not None
         assert collections[0].title == "place"
+
     """Tests for the build_release_catalog method."""
 
     @patch("overture_stac.overture_stac.stac_geoparquet")

--- a/tests/test_process_theme_worker.py
+++ b/tests/test_process_theme_worker.py
@@ -221,7 +221,51 @@ class TestProcessThemeWorker:
         assert len(pmtiles_links) == 1
 
 
-class TestBuildReleaseCatalog:
+    @patch("overture_stac.overture_stac.ds")
+    @patch("overture_stac.overture_stac.fs")
+    def test_child_links_have_titles(self, mock_fs, mock_ds):
+        """Verify all child links on theme_catalog include a title field."""
+        fragments = [
+            make_mock_fragment(
+                "bucket/release/theme=places/type=place/part-00000-abc.parquet",
+                num_rows=50,
+            ),
+        ]
+
+        file_info, dataset = make_mock_theme_type(
+            "bucket/release/theme=places/type=place", fragments
+        )
+
+        mock_filesystem = MagicMock()
+        mock_filesystem.get_file_info.return_value = [file_info]
+        mock_fs.S3FileSystem.return_value = mock_filesystem
+        mock_ds.dataset.return_value = dataset
+
+        theme_catalog, _, _, _ = process_theme_worker(
+            theme_path="bucket/release/theme=places",
+            release_path="s3://bucket/release",
+            s3_region="us-west-2",
+            debug=False,
+            release_datetime=datetime(2026, 4, 15),
+            release="2026-04-15.0",
+            available_pmtiles={},
+        )
+
+        child_links = [link for link in theme_catalog.links if link.rel == "child"]
+        assert len(child_links) > 0, "theme_catalog should have child links"
+        for link in child_links:
+            assert link.title is not None, (
+                f"Child link {link.href} is missing a title field"
+            )
+
+        # Also verify the theme_catalog itself has a title
+        assert theme_catalog.title is not None
+        assert theme_catalog.title == "places"
+
+        # Verify collection has a title
+        collections = list(theme_catalog.get_children())
+        assert collections[0].title is not None
+        assert collections[0].title == "place"
     """Tests for the build_release_catalog method."""
 
     @patch("overture_stac.overture_stac.stac_geoparquet")

--- a/tests/test_process_theme_worker.py
+++ b/tests/test_process_theme_worker.py
@@ -266,6 +266,8 @@ class TestProcessThemeWorker:
         assert collections[0].title is not None
         assert collections[0].title == "place"
 
+
+class TestBuildReleaseCatalog:
     """Tests for the build_release_catalog method."""
 
     @patch("overture_stac.overture_stac.stac_geoparquet")

--- a/uv.lock
+++ b/uv.lock
@@ -310,7 +310,7 @@ wheels = [
 
 [[package]]
 name = "overture-stac"
-version = "1.0.7"
+version = "1.0.8"
 source = { editable = "." }
 dependencies = [
     { name = "pyarrow" },

--- a/uv.lock
+++ b/uv.lock
@@ -310,7 +310,7 @@ wheels = [
 
 [[package]]
 name = "overture-stac"
-version = "1.0.6"
+version = "1.0.7"
 source = { editable = "." }
 dependencies = [
     { name = "pyarrow" },


### PR DESCRIPTION
## Changes

* Set title attributes on STAC Catalog and Collection objects so generated child links include a title. 
* Pass the title when adding child collections to ensure `link.title` is populated. 
* Add a unit test to verify theme and child collection titles are present, and add a title to the overture releases catalog in the CLI.

## Validation

Before, when [run on main](https://github.com/OvertureMaps/stac/actions/runs/25804775371/job/75804320314), we see this in the stac-check output:

```
 Asset 1: tests/data/catalog.json

CATALOG Passed: True

Schemas checked: 
    https://schemas.stacspec.org/v1.1.0/catalog-spec/json-schema/catalog.json



 STAC Best Practices: 

Links in catalogs and collections should always have a 'title' field
```

And now, this is no longer flagged by stac-check in CI. Our staging build of the catalog also shows that `title` is populated now in all uses of `link` (prior was just *some*):

```diff
# https://staging.overturemaps.org/stac/pr/62/catalog.json
{
  "type": "Catalog",
  "id": "Overture Releases",
  "stac_version": "1.1.0",
  "description": "All Overture Releases",
  "links": [
    {
      "rel": "root",
      "href": "./catalog.json",
      "type": "application/json",
+     "title": "Overture Releases"
    },
    {
      "rel": "child",
      "href": "./2026-04-15.0/catalog.json",
      "type": "application/json",
      "title": "Latest Overture Release",
      "latest": true
    },
    {
      "rel": "child",
      "href": "./2026-03-18.0/catalog.json",
      "type": "application/json",
      "title": "2026-03-18.0 Overture Release"
    }
  ],
```