### PR TITLE
[CHORE] Bump version to 1.0.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "overture-stac"
-version = "1.0.8"
+version = "1.0.9"
 description = "Generate STAC catalogs for Overture Maps Releases"
 authors = [
     {name = "Overture Maps Foundation"}


### PR DESCRIPTION
## Summary

- Bumps `pyproject.toml` version from `1.0.8` to `1.0.9`
- Fixes failed PyPI publish on the `v1.0.9` release — tag was created before version was bumped, causing a `400 Bad Request` (version `1.0.8` already existed on PyPI)

## After merging

Delete and re-create the `v1.0.9` GitHub release pointing at this commit to re-trigger the publish workflow.

Closes #60