### PR TITLE
[CHORE] Bump version to 1.0.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "overture-stac"
-version = "1.0.9"
+version = "1.0.10"
 description = "Generate STAC catalogs for Overture Maps Releases"
 authors = [
     {name = "Overture Maps Foundation"}


### PR DESCRIPTION
Bumps `pyproject.toml` version to `1.0.10`. Skipping `1.0.9` — immutable releases being enabled.

After merging, create a new `v1.0.10` GitHub release to trigger the publish workflow.

Closes #60