### PR TITLE
[CHORE] Bump version to 1.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "overture-stac"
-version = "1.0.10"
+version = "1.1.1"
 description = "Generate STAC catalogs for Overture Maps Releases"
 authors = [
     {name = "Overture Maps Foundation"}


### PR DESCRIPTION
## What

Bump `pyproject.toml` version from `1.0.10` to `1.1.1`.

## Why

Release `v1.1.0` failed to publish to PyPI with `400 Bad Request` — the built artifact was still versioned `1.0.10`, which already exists on PyPI. Skipping `1.1.0` to avoid confusion with the failed release tag.

## Testing

- [ ] CI publishes to PyPI successfully on next release tag

Closes #73