### PR TITLE
[BUG] Add missing self links via ABSOLUTE_PUBLISHED catalog

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -123,16 +123,29 @@ jobs:
         run: uv sync --all-groups
 
       - name: Generate local STAC catalog (debug mode)
-        run: uv run python tests/setup_test_catalog.py --output tests/data --workers 2
+        run: uv run python tests/setup_test_catalog.py --output "$GITHUB_WORKSPACE/tests/data" --workers 2
+
+      - name: Serve STAC catalog locally
+        run: |
+          uv run python tests/setup_test_catalog.py --serve-only --output "$GITHUB_WORKSPACE/tests/data" &
+          echo $! > server.pid
+          for i in $(seq 1 20); do
+            curl -sf http://127.0.0.1:8888/catalog.json > /dev/null && break
+            sleep 0.5
+          done
 
       - name: Validate root catalog
         uses: OvertureMaps/stac-check-action@3b06576bbf96c8d172f627c1639ac128f4fd7e38 # v1.0.0
         with:
           stac-check-version: "1.14.0"
-          file: tests/data/catalog.json
+          file: http://127.0.0.1:8888/catalog.json
           recursive: "true"
           fast-linting: "true"
           job-summary: "true"
+
+      - name: Stop local server
+        if: always()
+        run: kill $(cat server.pid) 2>/dev/null || true
 
   all-checks-pass:
     name: All Checks Pass

--- a/.github/workflows/staging.yaml
+++ b/.github/workflows/staging.yaml
@@ -37,7 +37,8 @@ jobs:
 
       - name: Build STAC Catalog
         run: |
-          gen-stac --output public_releases
+          gen-stac --output public_releases \
+            --root-href "https://staging.overturemaps.org/${{ github.event.repository.name }}/pr/${{ github.event.number }}"
 
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/staging.yaml
+++ b/.github/workflows/staging.yaml
@@ -36,9 +36,12 @@ jobs:
           uv pip install --system -e .
 
       - name: Build STAC Catalog
+        env:
+          REPO_NAME: ${{ github.event.repository.name }}
+          PR_NUMBER: ${{ github.event.number }}
         run: |
           gen-stac --output public_releases \
-            --root-href "https://staging.overturemaps.org/${{ github.event.repository.name }}/pr/${{ github.event.number }}"
+            --root-href "https://staging.overturemaps.org/${REPO_NAME}/pr/${PR_NUMBER}"
 
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,6 @@ test_output/
 *~
 
 tests/data
+
+# Local tooling cache
+.impeccable/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "overture-stac"
-version = "1.1.1"
+version = "1.2.0"
 description = "Generate STAC catalogs for Overture Maps Releases"
 authors = [
     {name = "Overture Maps Foundation"}

--- a/src/overture_stac/cli.py
+++ b/src/overture_stac/cli.py
@@ -10,6 +10,8 @@ import pystac
 from overture_stac.overture_stac import OvertureRelease
 from overture_stac.registry_manifest import RegistryManifest
 
+PROD_ROOT_HREF = "https://stac.overturemaps.org"
+
 
 def main():
     """Main entry point for the CLI."""
@@ -52,7 +54,20 @@ def main():
         help="Schema version for the release (e.g. 1.17.0). Required when --release is provided.",
     )
 
+    parser.add_argument(
+        "--root-href",
+        type=str,
+        default=PROD_ROOT_HREF,
+        help=(
+            "Public root URL the catalog will be hosted at, used to build absolute "
+            f"'self' links (default: {PROD_ROOT_HREF}). Override for staging/testing, "
+            "e.g. https://labs.overturemaps.org/stac."
+        ),
+    )
+
     args = parser.parse_args()
+
+    root_href = args.root_href.rstrip("/")
 
     if args.release and not args.schema_version:
         parser.error("--schema-version is required when --release is provided")
@@ -75,9 +90,10 @@ def main():
         )
         title = f"{args.release} Overture Release"
         this_release.build_release_catalog(title=title, max_workers=args.workers)
-        this_release.release_catalog.normalize_and_save(
-            root_href=str(output / args.release),
-            catalog_type=pystac.CatalogType.SELF_CONTAINED,
+        this_release.release_catalog.normalize_hrefs(f"{root_href}/{args.release}/")
+        this_release.release_catalog.save(
+            catalog_type=pystac.CatalogType.ABSOLUTE_PUBLISHED,
+            dest_href=str(output / args.release),
         )
         return
 
@@ -125,8 +141,9 @@ def main():
         "manifest": registry_manifest.create_manifest(),
     }
 
-    overture_releases_catalog.normalize_and_save(
-        root_href=str(output), catalog_type=pystac.CatalogType.SELF_CONTAINED
+    overture_releases_catalog.normalize_hrefs(f"{root_href}/")
+    overture_releases_catalog.save(
+        catalog_type=pystac.CatalogType.ABSOLUTE_PUBLISHED, dest_href=str(output)
     )
 
 

--- a/src/overture_stac/cli.py
+++ b/src/overture_stac/cli.py
@@ -67,6 +67,8 @@ def main():
 
     args = parser.parse_args()
 
+    # Normalize to no trailing slash so downstream f"{root_href}/..." hrefs
+    # always join with exactly one slash, regardless of user input.
     root_href = args.root_href.rstrip("/")
 
     if args.release and not args.schema_version:

--- a/tests/setup_test_catalog.py
+++ b/tests/setup_test_catalog.py
@@ -138,7 +138,8 @@ def build_test_catalog(
     # except Exception as e:
     #     logger.warning(f"Could not create registry manifest: {e}")
 
-    # Normalize and save
+    # Normalize and save. Strip any trailing slash from user input first so
+    # the appended "/" below always joins with exactly one slash.
     logger.info(f"Saving catalog to {output_dir}...")
     root_catalog.normalize_hrefs(root_href.rstrip("/") + "/")
     root_catalog.save(

--- a/tests/setup_test_catalog.py
+++ b/tests/setup_test_catalog.py
@@ -72,6 +72,7 @@ def build_test_catalog(
     output_dir: Path,
     release: str | None = None,
     workers: int = 2,
+    root_href: str = f"http://localhost:{DEFAULT_PORT}",
 ) -> Path:
     """
     Build a STAC catalog in debug mode for testing.
@@ -80,6 +81,9 @@ def build_test_catalog(
         output_dir: Directory to output the catalog
         release: Specific release to build (None = latest)
         workers: Number of parallel workers
+        root_href: Public root URL used to build absolute 'self' links. Should
+            match wherever the catalog will actually be served from (e.g. the
+            local test HTTP server) so hierarchical links resolve correctly.
 
     Returns:
         Path to the built catalog directory
@@ -136,9 +140,10 @@ def build_test_catalog(
 
     # Normalize and save
     logger.info(f"Saving catalog to {output_dir}...")
-    root_catalog.normalize_and_save(
-        root_href=str(output_dir),
-        catalog_type=pystac.CatalogType.SELF_CONTAINED,
+    root_catalog.normalize_hrefs(root_href.rstrip("/") + "/")
+    root_catalog.save(
+        catalog_type=pystac.CatalogType.ABSOLUTE_PUBLISHED,
+        dest_href=str(output_dir),
     )
 
     catalog_path = output_dir / release
@@ -268,6 +273,16 @@ def main():
         help=f"Port for HTTP server (default: {DEFAULT_PORT})",
     )
 
+    parser.add_argument(
+        "--root-href",
+        type=str,
+        default=None,
+        help=(
+            "Public root URL used to build absolute 'self' links. Defaults to "
+            "http://localhost:<port>, matching the local test HTTP server."
+        ),
+    )
+
     args = parser.parse_args()
 
     if args.list_releases:
@@ -289,10 +304,12 @@ def main():
         return
 
     # Build the catalog
+    root_href = args.root_href or f"http://localhost:{args.port}"
     catalog_path = build_test_catalog(
         output_dir=output_dir,
         release=args.release,
         workers=args.workers,
+        root_href=root_href,
     )
 
     print("\n✓ Test catalog built successfully!")

--- a/tests/setup_test_catalog.py
+++ b/tests/setup_test_catalog.py
@@ -18,7 +18,7 @@ import os
 import sys
 import threading
 from functools import partial
-from http.server import HTTPServer, SimpleHTTPRequestHandler
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
 import pyarrow.fs as fs
@@ -72,7 +72,7 @@ def build_test_catalog(
     output_dir: Path,
     release: str | None = None,
     workers: int = 2,
-    root_href: str = f"http://localhost:{DEFAULT_PORT}",
+    root_href: str = f"http://127.0.0.1:{DEFAULT_PORT}",
 ) -> Path:
     """
     Build a STAC catalog in debug mode for testing.
@@ -169,7 +169,7 @@ class CORSRequestHandler(SimpleHTTPRequestHandler):
         logger.debug(f"HTTP: {args[0]}")
 
 
-def serve_catalog(directory: Path, port: int = DEFAULT_PORT) -> HTTPServer:
+def serve_catalog(directory: Path, port: int = DEFAULT_PORT) -> ThreadingHTTPServer:
     """
     Start an HTTP server to serve the catalog directory.
 
@@ -178,19 +178,22 @@ def serve_catalog(directory: Path, port: int = DEFAULT_PORT) -> HTTPServer:
         port: Port to serve on
 
     Returns:
-        HTTPServer instance
+        ThreadingHTTPServer instance
     """
     os.chdir(directory)
     handler = partial(CORSRequestHandler, directory=directory)
-    server = HTTPServer(("localhost", port), handler)
+    # Bind explicitly to the IPv4 loopback address (rather than "localhost")
+    # to avoid slow IPv6-then-IPv4 connection fallback delays seen with some
+    # HTTP clients (e.g. requests/urllib3 on Windows).
+    server = ThreadingHTTPServer(("127.0.0.1", port), handler)
     return server
 
 
 def run_server_blocking(directory: Path, port: int = DEFAULT_PORT):
     """Run the HTTP server in blocking mode (for CLI use)."""
     server = serve_catalog(directory, port)
-    print(f"Serving catalog at http://localhost:{port}")
-    print(f"Root catalog: http://localhost:{port}/catalog.json")
+    print(f"Serving catalog at http://127.0.0.1:{port}")
+    print(f"Root catalog: http://127.0.0.1:{port}/catalog.json")
     print("Press Ctrl+C to stop...")
 
     try:
@@ -203,7 +206,9 @@ def run_server_blocking(directory: Path, port: int = DEFAULT_PORT):
         print("Server stopped.")
 
 
-def start_server_background(directory: Path, port: int = DEFAULT_PORT) -> HTTPServer:
+def start_server_background(
+    directory: Path, port: int = DEFAULT_PORT
+) -> ThreadingHTTPServer:
     """
     Start the HTTP server in a background thread.
 
@@ -212,12 +217,12 @@ def start_server_background(directory: Path, port: int = DEFAULT_PORT) -> HTTPSe
         port: Port to serve on
 
     Returns:
-        HTTPServer instance (call shutdown() to stop)
+        ThreadingHTTPServer instance (call shutdown() to stop)
     """
     server = serve_catalog(directory, port)
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
-    logger.info(f"Server started at http://localhost:{port}")
+    logger.info(f"Server started at http://127.0.0.1:{port}")
     return server
 
 
@@ -279,7 +284,7 @@ def main():
         default=None,
         help=(
             "Public root URL used to build absolute 'self' links. Defaults to "
-            "http://localhost:<port>, matching the local test HTTP server."
+            "http://127.0.0.1:<port>, matching the local test HTTP server."
         ),
     )
 
@@ -304,7 +309,7 @@ def main():
         return
 
     # Build the catalog
-    root_href = args.root_href or f"http://localhost:{args.port}"
+    root_href = args.root_href or f"http://127.0.0.1:{args.port}"
     catalog_path = build_test_catalog(
         output_dir=output_dir,
         release=args.release,

--- a/tests/test_e2e_stac_catalog.py
+++ b/tests/test_e2e_stac_catalog.py
@@ -51,7 +51,7 @@ def find_release_name() -> str | None:
 def is_port_in_use(port: int) -> bool:
     """Check if a port is already in use."""
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        return s.connect_ex(("localhost", port)) == 0
+        return s.connect_ex(("127.0.0.1", port)) == 0
 
 
 def get_all_items_from_catalog(catalog: pystac.Catalog) -> list[pystac.Item]:
@@ -105,7 +105,7 @@ def catalog_server():
     # Check if server is already running
     if is_port_in_use(port):
         # Assume it's our server already running
-        yield f"http://localhost:{port}"
+        yield f"http://127.0.0.1:{port}"
         return
 
     # Start the server
@@ -113,7 +113,7 @@ def catalog_server():
     time.sleep(0.5)  # Give server time to start
 
     try:
-        yield f"http://localhost:{port}"
+        yield f"http://127.0.0.1:{port}"
     finally:
         # Properly shutdown and close the server
         server.shutdown()

--- a/uv.lock
+++ b/uv.lock
@@ -310,7 +310,7 @@ wheels = [
 
 [[package]]
 name = "overture-stac"
-version = "1.0.10"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "pyarrow" },


### PR DESCRIPTION
## Summary
Fixes #51 — catalogs/collections/items were missing the STAC best-practice `self` link.

## Motivation
Catalogs were saved with `CatalogType.SELF_CONTAINED`, which per the [STAC best practices spec](https://github.com/radiantearth/stac-spec/blob/master/best-practices.md#use-of-links) intentionally omits `self` links, unlike `CatalogType.ABSOLUTE_PUBLISHED`:

> While STAC is useful as a portable format to move between systems, **the goal is really to enable search**. While any combination of absolute and relative links is technically allowed by the specification, **it is strongly recommended to follow one of the [non self-contained] patterns described below when publishing online.** 

But our catalogs are always hosted at a known public URL - prod (`https://stac.overturemaps.org`) or a per-PR staging deploy (`https://staging.overturemaps.org/.../pr/<n>/`) - so `SELF_CONTAINED` was the wrong catalog type for this use case, since we're publishing online.

## Change
- Switch to `pystac.CatalogType.ABSOLUTE_PUBLISHED` when saving, so every catalog, collection, and item gets an absolute `self` link.
- Add a `--root-href` CLI flag (default: `https://stac.overturemaps.org`) so the public root URL used to build `self` links (and all hierarchical links - child/parent/item/root) can be overridden for testing/staging (e.g. `https://labs.overturemaps.org/stac`).

The net effects are summarized by looking at an [old](https://stac.overturemaps.org/2026-06-17.0/addresses/address/00000/00000.json) vs [new](https://staging.overturemaps.org/stac/pr/78/2026-06-17.0/addresses/address/00000/00000.json) json:

  ```diff
     "links": [
       {
         "rel": "root",
  -      "href": "../../../../catalog.json"
  +      "href": "https://stac.overturemaps.org/catalog.json"
       },
       {
         "rel": "collection",
  -      "href": "../collection.json"
  +      "href": "https://stac.overturemaps.org/2026-06-17.0/addresses/address/collection.json"
       },
       {
         "rel": "parent",
  -      "href": "../collection.json"
  +      "href": "https://stac.overturemaps.org/2026-06-17.0/addresses/address/collection.json"
  -      },
  +      },
  +      {
  +        "rel": "self",
  +        "href": "https://stac.overturemaps.org/2026-06-17.0/addresses/address/00000/00000.json"
  +      }
     ]
  ```

Because both relative (for portable, testing, etc.) and published STAC approaches are part of the spec, all downstream clients/readers should be able to read the absolute URLs natively, without any configuration changes. For this reason, the change is a `minor` instead of a `major`, breaking change for the tool.


## Testing
- Full e2e integration suite (26 tests) passed against a real catalog built from live S3 data.
- `stac-check` recursive validation passes with no self-link warnings; CI is green end-to-end.

### Added

- Updated `tests/setup_test_catalog.py`, defaulting to the local test HTTP server so the e2e integration tests continue to pass.
- Updated the CI `stac-validate` job to serve the generated test catalog over a local HTTP server (rather than validating the file directly), since recursive validation now needs to follow absolute `self`/child hrefs.
- Switched the local dev/test HTTP server to `ThreadingHTTPServer` bound to `127.0.0.1` (instead of `localhost`) to avoid slow IPv6-then-IPv4 connection fallback delays that were causing recursive validation to time out.
