### PR TITLE
[DOCS] Replace labs.overturemaps.org refs with stac.overturemaps.org

### DIFF
--- a/.github/workflows/publish-stac.yaml
+++ b/.github/workflows/publish-stac.yaml
@@ -45,6 +45,12 @@ jobs:
           </html>
           HTML
 
+          # GitHub Pages serves 404.html for any unmatched path, so this also
+          # catches old deep links (e.g. /stac/catalog.json, /stac/collections/...)
+          # that pointed at real files before this workflow stopped building
+          # the catalog.
+          cp redirect_page/index.html redirect_page/404.html
+
       - name: Setup Pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 

--- a/.github/workflows/publish-stac.yaml
+++ b/.github/workflows/publish-stac.yaml
@@ -1,4 +1,4 @@
-name: Publish STAC to GH-Pages
+name: Publish Redirect Page to GH-Pages
 
 on:
   workflow_dispatch:
@@ -10,11 +10,13 @@ concurrency:
   group: "pages"
   cancel-in-progress: false
 
+# labs.overturemaps.org/stac is defunct. This workflow no longer builds the
+# STAC catalog; it publishes a single static page that redirects visitors to
+# the production STAC at https://stac.overturemaps.org/catalog.json.
 jobs:
-  build-and-deploy:
-    name: Build and Deploy STAC Catalog
+  deploy-redirect:
+    name: Deploy Redirect Page
     permissions:
-      contents: read
       pages: write # required to deploy to GitHub Pages
       id-token: write # required for OIDC token exchange when deploying to GitHub Pages
     environment:
@@ -22,26 +24,26 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-
-      - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
-        with:
-          python-version-file: .python-version
-
-      - name: Install UV
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
-
-      - name: Install dependencies
+      - name: Generate redirect page
         run: |
-          uv pip install --system -e .
-
-      - name: Build STAC Catalog
-        run: |
-          gen-stac --output public_releases
+          mkdir -p redirect_page
+          cat > redirect_page/index.html <<'HTML'
+          <!DOCTYPE html>
+          <html lang="en">
+          <head>
+            <meta charset="utf-8">
+            <title>Overture STAC has moved</title>
+            <meta http-equiv="refresh" content="0; url=https://stac.overturemaps.org/catalog.json">
+            <link rel="canonical" href="https://stac.overturemaps.org/catalog.json">
+          </head>
+          <body>
+            <p>
+              This STAC catalog has moved. Redirecting to
+              <a href="https://stac.overturemaps.org/catalog.json">https://stac.overturemaps.org/catalog.json</a>.
+            </p>
+          </body>
+          </html>
+          HTML
 
       - name: Setup Pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
@@ -49,7 +51,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
-          path: "public_releases"
+          path: "redirect_page"
 
       - name: Deploy to GitHub Pages
         id: deployment

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Generate STAC catalogs for all public Overture Maps releases.
 
-**[Browse the catalog](https://radiantearth.github.io/stac-browser/#/external/labs.overturemaps.org/stac/catalog.json?.language=en)**
+**[Browse the catalog](https://radiantearth.github.io/stac-browser/#/external/stac.overturemaps.org/catalog.json?.language=en)**
 
 ## Setup
 

--- a/src/overture_stac/cli.py
+++ b/src/overture_stac/cli.py
@@ -61,7 +61,7 @@ def main():
         help=(
             "Public root URL the catalog will be hosted at, used to build absolute "
             f"'self' links (default: {PROD_ROOT_HREF}). Override for staging/testing, "
-            "e.g. https://labs.overturemaps.org/stac."
+            "e.g. https://staging.overturemaps.org/stac/pr/123."
         ),
     )
 


### PR DESCRIPTION
Fixes #82.

`https://labs.overturemaps.org/stac` is defunct and `https://stac.overturemaps.org` is the authoritative STAC home.

## Changes
- `README.md`: catalog browse link now points at `stac.overturemaps.org/catalog.json` instead of the old labs domain.
- `src/overture_stac/cli.py`: `--root-href` help text example updated to reference the staging domain (`staging.overturemaps.org/stac/pr/...`) instead of labs, since that's the actual valid non-prod override case.
- `.github/workflows/publish-stac.yaml`: no longer builds the full STAC catalog for GH Pages. Instead it publishes a static `index.html` (and cp of that as `404.html`) that redirects visitors to `https://stac.overturemaps.org/catalog.json`, so `labs.overturemaps.org/stac` becomes a pure redirect as called for in the issue AC.
   - This is good for repo-level posterity, and to provide a breadcrumb trail for any users of the legacy endpoint 
- URL meta on the GitHub Repository has been manually updated:
   -  <img width="388" height="170" alt="{9E68A6CC-6B74-4858-B465-6CC107FAED25}" src="https://github.com/user-attachments/assets/223756f5-6521-454a-be00-a6f1bc20c95f" />
  

Confirmed no other `labs.overturemaps.org` references remain in the repo (code or docs).

## Followup

A one-time manual exec of the `publish-stac` workflow to push the new index / 404 pages.