### PR TITLE
[CHORE] Add Overture issue template and issue field sync workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/overture.yaml
+++ b/.github/ISSUE_TEMPLATE/overture.yaml
@@ -1,0 +1,51 @@
+name: Overture
+description: General issue for work tracked in the Overture project.
+projects: ["OvertureMaps/84"]
+body:
+  - type: dropdown
+    id: type
+    attributes:
+      label: Type
+      description: What kind of work is this? Used to populate the organization-level `Type` field during triage.
+      options:
+        - Task
+        - Bug
+        - Agenda
+    validations:
+      required: true
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Scope
+      description: Primary theme or platform impacted. Used to populate the organization-level `Scope` field during triage.
+      default: 6
+      options:
+        - Addresses
+        - Base
+        - Buildings
+        - Divisions
+        - Places
+        - Transportation
+        - Multi-theme or Platform
+    validations:
+      required: true
+  - type: dropdown
+    id: skillset
+    attributes:
+      label: Skillset
+      description: Primary skill needed to complete this task. Used to populate the organization-level `Skillset` field during triage.
+      default: 2
+      options:
+        - data analysis
+        - data science
+        - dev ops
+        - engineering
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      placeholder: Describe what this issue is trying to accomplish (what), context (why), constraints, acceptance criteria, design details (how), and testing
+    validations:
+      required: true

--- a/.github/workflows/sync-issue-type-and-scope.yml
+++ b/.github/workflows/sync-issue-type-and-scope.yml
@@ -4,6 +4,9 @@ on:
   issues:
     types: [opened]
 
+# Jobs opt in to the permissions they need.
+permissions: {}
+
 # One sync run per issue at a time; drop duplicate triggers.
 concurrency:
   group: sync-issue-type-scope-${{ github.event.issue.number }}
@@ -11,8 +14,10 @@ concurrency:
 
 jobs:
   sync-fields:
+    name: Sync issue fields
     runs-on: ubuntu-latest
     permissions:
+      # Needed to set the Type, Scope, and Skillset fields on the opened issue.
       issues: write
     steps:
       - name: Sync Type and Scope from form answers

--- a/.github/workflows/sync-issue-type-and-scope.yml
+++ b/.github/workflows/sync-issue-type-and-scope.yml
@@ -1,0 +1,21 @@
+name: Sync issue Type and Scope
+
+on:
+  issues:
+    types: [opened]
+
+# One sync run per issue at a time; drop duplicate triggers.
+concurrency:
+  group: sync-issue-type-scope-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  sync-fields:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Sync Type and Scope from form answers
+        uses: OvertureMaps/workflows/.github/actions/sync-issue-fields@main # zizmor: ignore[unpinned-uses] intentionally track main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync-issue-type-and-scope.yml
+++ b/.github/workflows/sync-issue-type-and-scope.yml
@@ -17,8 +17,7 @@ jobs:
     name: Sync issue fields
     runs-on: ubuntu-latest
     permissions:
-      # Needed to set the Type, Scope, and Skillset fields on the opened issue.
-      issues: write
+      issues: write # Needed to set the Type, Scope, and Skillset fields on the opened issue.
     steps:
       - name: Sync Type and Scope from form answers
         uses: OvertureMaps/workflows/.github/actions/sync-issue-fields@main # zizmor: ignore[unpinned-uses] intentionally track main


### PR DESCRIPTION
Closes #93

## Description

This repo had no `.github/ISSUE_TEMPLATE/` directory. This adds one, following the [GitHub usage operating procedures](https://github.com/OvertureMaps/operating-procedures/blob/main/development/github-usage.md) and the reference implementation in `tf-data-platform` (OvertureMaps/tf-data-platform#4623, OvertureMaps/tf-data-platform#4728), with repo-specific defaults.

### Changes

- **`.github/ISSUE_TEMPLATE/overture.yaml`** — the single template for this repo, adding issues to the `Overture` project (`OvertureMaps/84`). Prompts for `Type`, `Scope`, `Skillset`, and `Description`, all required.
  - `Type` offers `Task`, `Bug`, `Agenda` — no `Feature` value.
  - `Scope` offers all options, defaulting to `Multi-theme or Platform`.
  - `Skillset` offers all options, defaulting to `dev ops`.
  - No bracketed type prepended to the issue title.
- **`.github/ISSUE_TEMPLATE/config.yml`** — `blank_issues_enabled: false`.
- **`.github/workflows/sync-issue-type-and-scope.yml`** — runs on issue open and uses `OvertureMaps/workflows/.github/actions/sync-issue-fields@main` to populate the org-level fields from the form answers. Uses `ubuntu-latest` to match the other workflows in this repo.

## Test plan

- [x] All three files parse as valid YAML.
- [ ] Template renders in the "New issue" chooser with no parse errors and required fields validate.
- [ ] Dropdown defaults (`Multi-theme or Platform`, `dev ops`) are pre-selected on load.
- [ ] Create a test issue, confirm it lands in the `Overture` project and the sync workflow populates `Type`, `Scope`, and `Skillset`, then close it.

Note: the last three items can only be verified once this is merged to `main`, since GitHub only reads issue templates and `issues:` workflow triggers from the default branch.