### PR TITLE
[CHORE] Make Skillset field optional in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/overture.yaml
+++ b/.github/ISSUE_TEMPLATE/overture.yaml
@@ -33,7 +33,7 @@ body:
     id: skillset
     attributes:
       label: Skillset
-      description: Primary skill needed to complete this task. Used to populate the organization-level `Skillset` field during triage.
+      description: Primary skill needed to complete this task. Used to populate the organization-level `Skillset` field during triage. Optional - leave blank if none of these options describe the needed skillset.
       default: 2
       options:
         - data analysis
@@ -41,7 +41,7 @@ body:
         - dev ops
         - engineering
     validations:
-      required: true
+      required: false
   - type: textarea
     id: description
     attributes:


### PR DESCRIPTION
## What

The org-level `Skillset` custom field was added to `.github/ISSUE_TEMPLATE/overture.yaml` as a **required** dropdown. It should be optional.

Changes to the `skillset` dropdown block:
- `validations.required`: `true` -> `false`
- Appended to the description: `Optional - leave blank if none of these options describe the needed skillset.`

No other field's `required` setting was touched (`type`, `scope`, `description` remain required).

## Why

The option list (data analysis, data science, dev ops, engineering) is not all-inclusive, so contributors must be able to leave the field blank rather than pick an inaccurate value.

## Impact

Issue form metadata only. No runtime, architecture, API, schema, or cost impact. `sync-issue-type-and-scope.yml` reads the form answer during triage and simply receives an empty value when the contributor leaves it blank.

## Assumptions

- `overture.yaml` is the only issue form in this repo with an `id: skillset` dropdown (verified by a case-insensitive repo-wide grep).
- Downstream triage automation tolerates an empty Skillset value.

## Verification

- YAML parses and `skillset` is the only field whose `required` flag changed; the diff against `main` contains only the `required` flip and the description text.
- `uvx zizmor@1.29.0 --persona=pedantic .` reports no findings, so no separate workflow-hardening commit was needed here.

Closes https://github.com/OvertureMaps/omf_staff/issues/149