### PR TITLE
[FEATURE] Prototype Rust port of `gen-stac` using `stac` + `object_store`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,6 @@ tests/data
 
 # Local tooling cache
 .impeccable/
+
+py_output/
+rust_output/

--- a/justfile
+++ b/justfile
@@ -72,3 +72,26 @@ serve:
 # Remove all generated catalog outputs.
 clean:
     rm -rf {{OUTPUT}} {{FIXTURE_DIR}}
+
+# --- Rust port (see rust/) ---
+
+RS := './rust/target/release/gen-stac-rs'
+
+# Build the Rust CLI in release mode.
+rs-build:
+    cd rust && cargo build --release
+
+# Run the Rust CLI against a release. Pass --debug via CARGS='--debug' for a fast run.
+rs-run schema release CARGS='--debug': rs-build
+    {{RS}} {{CARGS}} --output rust_output --workers 6 --release {{release}} --schema-version {{schema}}
+
+# Run BOTH implementations against the same release and diff every JSON file.
+rs-compare schema release CARGS='--debug': sync rs-build
+    rm -rf py_output rust_output
+    uv run gen-stac {{CARGS}} --output py_output --workers 6 --release {{release}} --schema-version {{schema}}
+    {{RS}} {{CARGS}} --output rust_output --workers 6 --release {{release}} --schema-version {{schema}}
+    diff -r --brief py_output rust_output || true
+
+# Run the Rust unit tests.
+rs-test:
+    cd rust && cargo test

--- a/rust/.gitignore
+++ b/rust/.gitignore
@@ -1,0 +1,2 @@
+/target
+Cargo.lock

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "overture-stac-rs"
+version = "0.1.0"
+edition = "2021"
+description = "Rust port of the Overture STAC catalog generator"
+license = "MIT"
+
+[[bin]]
+name = "gen-stac-rs"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = "1"
+bytes = "1"
+chrono = "0.4"
+clap = { version = "4", features = ["derive"] }
+futures = "0.3"
+object_store = { version = "0.13", features = ["aws"] }
+parquet = { version = "59", features = ["async", "object_store"] }
+regex = "1"
+serde_json = { version = "1", features = ["float_roundtrip"] }
+stac = { version = "0.17.4", features = ["geoparquet"] }
+stac-io = { version = "0.3.2", features = ["geoparquet"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/rust/README.md
+++ b/rust/README.md
@@ -1,0 +1,44 @@
+# overture-stac-rs
+
+Rust port of `overture_stac` (`../src/overture_stac/`). Semantic parity with the Python `gen-stac` CLI — same STAC output, faster and more resilient to transient S3 errors.
+
+## Build
+
+```sh
+cd rust
+cargo build --release
+```
+
+## Run
+
+Same flags as the Python CLI:
+
+```sh
+cargo run --release -- \
+  --release 2026-07-22.0 \
+  --schema-version 1.18.0 \
+  --output ../rust_output \
+  --workers 6
+```
+
+Or from the repo root: `just rs-run 1.18.0 2026-07-22.0` (debug) / `just rs-run 1.18.0 2026-07-22.0 CARGS=''` (full).
+
+## Parity strategy
+
+Semantic, not byte-identical. Field order and whitespace follow the `stac` crate's Serialize impls, which differ from `pystac`'s output. Content matches: same catalog/collection/item structure, same items, same asset hrefs, same extension fields.
+
+- Catalog/Collection/Item modeled via the `stac` crate (`Catalog`, `Collection`, `Item`, `Link`, `Asset`, `Bbox`, `Extent`).
+- OMF-specific extension fields (`storage:schemes`, `table:columns`, `release:version`, etc.) live in `additional_fields`.
+- `collections.parquet` written via `stac`'s `geoparquet` feature (`ItemCollection::into_geoparquet_path`).
+- Parquet fragment metadata read via `object_store` + `parquet::ParquetMetaDataReader::load_via_suffix_and_finish` — one ranged suffix GET per fragment, no HEAD.
+
+## Verify against Python
+
+From the repo root:
+
+```sh
+just rs-compare 1.18.0 2026-07-22.0            # debug: 3 fragments per type
+just rs-compare 1.18.0 2026-07-22.0 CARGS=''   # full
+```
+
+Prints any files that diverge. Note that Python's theme child ordering is non-deterministic (`ProcessPoolExecutor.as_completed`), so the release-level `catalog.json` and `manifest.geojson` will have permuted arrays — set content matches.

--- a/rust/src/catalog.rs
+++ b/rust/src/catalog.rs
@@ -1,0 +1,456 @@
+//! Assembly of the release catalog + the equivalent of pystac's
+//! `normalize_hrefs` + `save(catalog_type=ABSOLUTE_PUBLISHED)`.
+//!
+//! We build typed `stac::Catalog`, `stac::Collection`, `stac::Item` values via `theme.rs`,
+//! then walk the tree at save time — attaching root/parent/self/child/item links with
+//! absolute hrefs — and serialize each node via `stac_io::write` (which uses the `stac`
+//! crate's Serialize impls). `collections.parquet` is written via
+//! `stac::geoparquet` through the `ItemCollection::into_geoparquet_path` helper.
+
+use anyhow::{Context, Result};
+use chrono::{Datelike, NaiveDate, TimeZone, Utc};
+use serde_json::{Value, json};
+use stac::geoparquet::WriterOptions;
+use stac::{Catalog, Collection, Item, ItemCollection, Link};
+use stac_io::IntoGeoparquetPath;
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::sync::Arc;
+
+use crate::pmtiles;
+use crate::registry;
+use crate::s3::{Bucket, list_top_level};
+use crate::theme::{ITEM_STAC_EXTENSIONS, ThemeResult, process_theme};
+
+pub async fn list_release_ids(bucket: &Bucket, prefix: &str) -> Result<Vec<String>> {
+    let mut ids = list_top_level(bucket, prefix).await?;
+    ids.sort_by(|a, b| b.cmp(a));
+    Ok(ids)
+}
+
+/// Handle to a fully-assembled release, ready to save. Carries typed stac values plus
+/// the extras that only get materialized during `save_absolute_published`.
+pub struct ReleaseCatalog {
+    pub catalog: Catalog,
+    pub bundles: Vec<ThemeResult>,
+    /// Extra top-level links to attach after root (e.g. neighbor prev/next).
+    pub neighbor_links: Vec<Link>,
+    /// Optional list of child catalogs when this catalog is the multi-release root.
+    pub sub_children: Vec<ReleaseCatalog>,
+    /// Extra fields to render on this catalog's own `rel: child` link when it's nested
+    /// under a parent (e.g. `latest: true` on the newest release).
+    pub extra_child_fields: serde_json::Map<String, Value>,
+}
+
+pub async fn build_single_release(
+    bucket: &Bucket,
+    release: &str,
+    schema: &str,
+    title: &str,
+    debug: bool,
+    _workers: usize,
+    output: &Path,
+) -> Result<ReleaseCatalog> {
+    let out_dir = output.join(release);
+    std::fs::create_dir_all(&out_dir).with_context(|| format!("mkdir {}", out_dir.display()))?;
+
+    let release_date = release
+        .split('.')
+        .next()
+        .and_then(|d| NaiveDate::parse_from_str(d, "%Y-%m-%d").ok())
+        .with_context(|| format!("parse release date from {release}"))?;
+    let release_dt = Utc
+        .with_ymd_and_hms(release_date.year(), release_date.month(), release_date.day(), 0, 0, 0)
+        .single()
+        .expect("valid datetime");
+
+    let extras_bucket = crate::s3::new_public_bucket("overturemaps-extras-us-west-2", "us-west-2")?;
+    let available_pmtiles = pmtiles::discover(&extras_bucket, release).await;
+
+    let release_prefix = format!("release/{release}");
+    let mut theme_keys = list_top_level(bucket, &release_prefix).await?;
+    theme_keys.sort();
+    let theme_paths: Vec<String> = theme_keys
+        .into_iter()
+        .map(|k| format!("{release_prefix}/{k}"))
+        .collect();
+
+    let bucket_arc = Arc::new(bucket.clone_ref());
+    let pmtiles_arc = Arc::new(available_pmtiles);
+    let mut results = process_themes_parallel(
+        theme_paths,
+        bucket_arc,
+        release.to_string(),
+        debug,
+        release_dt,
+        pmtiles_arc,
+        4,
+    )
+    .await?;
+    results.sort_by(|a, b| a.theme_name.cmp(&b.theme_name));
+
+    // Write manifest.geojson + collections.parquet from the assembled items.
+    let mut manifest_items = Vec::new();
+    let mut all_items: Vec<Item> = Vec::new();
+    for r in &results {
+        manifest_items.extend(r.manifest_items.iter().cloned());
+        for (_, _, items, _) in &r.type_collections {
+            all_items.extend(items.iter().cloned());
+        }
+    }
+    let manifest = json!({"type": "FeatureCollection", "features": manifest_items});
+    std::fs::write(out_dir.join("manifest.geojson"), serde_json::to_vec(&manifest)?)?;
+    write_collections_parquet(&out_dir.join("collections.parquet"), all_items)?;
+
+    // Release catalog metadata.
+    let mut catalog = Catalog::new(
+        release,
+        format!("Geoparquet data released in the Overture {release} release"),
+    );
+    catalog.title = Some(title.to_string());
+    catalog.extensions = ITEM_STAC_EXTENSIONS.iter().map(|s| s.to_string()).collect();
+    catalog
+        .additional_fields
+        .insert("release:version".into(), json!(release));
+    if !schema.is_empty() {
+        catalog
+            .additional_fields
+            .insert("schema:version".into(), json!(schema));
+        catalog.additional_fields.insert(
+            "schema:tag".into(),
+            json!(format!(
+                "https://github.com/OvertureMaps/schema/releases/tag/v{schema}"
+            )),
+        );
+    }
+
+    Ok(ReleaseCatalog {
+        catalog,
+        bundles: results,
+        neighbor_links: Vec::new(),
+        sub_children: Vec::new(),
+        extra_child_fields: serde_json::Map::new(),
+    })
+}
+
+async fn process_themes_parallel(
+    theme_paths: Vec<String>,
+    bucket: Arc<Bucket>,
+    release: String,
+    debug: bool,
+    release_dt: chrono::DateTime<Utc>,
+    pmtiles: Arc<BTreeMap<String, String>>,
+    workers: usize,
+) -> Result<Vec<ThemeResult>> {
+    use futures::stream::{FuturesUnordered, StreamExt};
+    let mut in_flight = FuturesUnordered::new();
+    let mut paths_iter = theme_paths.into_iter();
+    let mut results = Vec::new();
+    for _ in 0..workers.max(1) {
+        if let Some(p) = paths_iter.next() {
+            in_flight.push(spawn_theme(bucket.clone(), p, release.clone(), debug, release_dt, pmtiles.clone()));
+        }
+    }
+    while let Some(r) = in_flight.next().await {
+        results.push(r?);
+        if let Some(p) = paths_iter.next() {
+            in_flight.push(spawn_theme(bucket.clone(), p, release.clone(), debug, release_dt, pmtiles.clone()));
+        }
+    }
+    Ok(results)
+}
+
+fn spawn_theme(
+    bucket: Arc<Bucket>,
+    theme_path: String,
+    release: String,
+    debug: bool,
+    release_dt: chrono::DateTime<Utc>,
+    pmtiles: Arc<BTreeMap<String, String>>,
+) -> impl std::future::Future<Output = Result<ThemeResult>> + Send + 'static {
+    async move {
+        process_theme(&bucket, &theme_path, &release, debug, release_dt, &pmtiles).await
+    }
+}
+
+pub fn link_neighbor_releases(catalog: &mut ReleaseCatalog, all_ids: &[String], root_href: &str) {
+    let id = catalog.catalog.id.clone();
+    let Some(idx) = all_ids.iter().position(|x| *x == id) else { return };
+    let root = root_href.trim_end_matches('/').to_string();
+    if idx > 0 {
+        let newer = &all_ids[idx - 1];
+        let mut l = Link::new(format!("{root}/{newer}/catalog.json"), "next");
+        l.r#type = Some("application/json".into());
+        l.title = Some(format!("{newer} Overture Release"));
+        catalog.neighbor_links.push(l);
+    }
+    if idx < all_ids.len() - 1 {
+        let older = &all_ids[idx + 1];
+        let mut l = Link::new(format!("{root}/{older}/catalog.json"), "prev");
+        l.r#type = Some("application/json".into());
+        l.title = Some(format!("{older} Overture Release"));
+        catalog.neighbor_links.push(l);
+    }
+}
+
+/// Save a ReleaseCatalog (or top-level Overture Releases catalog) under `dest`, using
+/// absolute self-hrefs rooted at `base_url`.
+pub fn save_absolute_published(release: &ReleaseCatalog, base_url: &str, dest: &Path) -> Result<()> {
+    let base_url = base_url.trim_end_matches('/').to_string();
+    std::fs::create_dir_all(dest)?;
+    let self_href = format!("{base_url}/catalog.json");
+    let root_title = release
+        .catalog
+        .title
+        .clone()
+        .unwrap_or_else(|| release.catalog.id.clone());
+    write_release(release, &base_url, &self_href, &self_href, &root_title, dest, None)
+}
+
+fn write_release(
+    release: &ReleaseCatalog,
+    base_url: &str,
+    self_href: &str,
+    root_href: &str,
+    root_title: &str,
+    dest: &Path,
+    parent: Option<(String, String)>,
+) -> Result<()> {
+    let mut catalog = release.catalog.clone();
+    catalog.links.clear();
+
+    // root
+    catalog.links.push(mk_link("root", root_href, Some("application/json"), Some(root_title)));
+
+    // children (themes for a release catalog; nested release catalogs for the top-level catalog)
+    for r in &release.bundles {
+        let href = format!("{}/{}/catalog.json", strip_last(self_href), r.theme_name);
+        let title = r.theme_catalog.title.clone().unwrap_or_else(|| r.theme_name.clone());
+        catalog.links.push(mk_link("child", &href, Some("application/json"), Some(&title)));
+    }
+    for c in &release.sub_children {
+        let href = format!("{}/{}/catalog.json", strip_last(self_href), c.catalog.id);
+        let title = c.catalog.title.clone().unwrap_or_else(|| c.catalog.id.clone());
+        let mut link = mk_link("child", &href, Some("application/json"), Some(&title));
+        for (k, v) in &c.extra_child_fields {
+            link.additional_fields.insert(k.clone(), v.clone());
+        }
+        catalog.links.push(link);
+    }
+
+    // neighbor prev/next
+    for l in &release.neighbor_links {
+        catalog.links.push(l.clone());
+    }
+
+    // parent
+    if let Some((h, t)) = &parent {
+        catalog.links.push(mk_link("parent", h, Some("application/json"), Some(t)));
+    }
+    // self
+    catalog.links.push(mk_link("self", self_href, Some("application/json"), None));
+
+    stac_io::write(dest.join("catalog.json"), catalog.clone())
+        .with_context(|| format!("write {}/catalog.json", dest.display()))?;
+
+    // Recurse: theme children
+    let self_title = release
+        .catalog
+        .title
+        .clone()
+        .unwrap_or_else(|| release.catalog.id.clone());
+    for r in &release.bundles {
+        let child_dir = dest.join(&r.theme_name);
+        std::fs::create_dir_all(&child_dir)?;
+        let child_self = format!("{}/{}/catalog.json", strip_last(self_href), r.theme_name);
+        write_theme(
+            r,
+            &child_self,
+            root_href,
+            root_title,
+            &child_dir,
+            (self_href.to_string(), self_title.clone()),
+        )?;
+    }
+    // Recurse: nested release catalogs
+    for c in &release.sub_children {
+        let child_dir = dest.join(&c.catalog.id);
+        std::fs::create_dir_all(&child_dir)?;
+        let child_self = format!("{}/{}/catalog.json", strip_last(self_href), c.catalog.id);
+        write_release(c, base_url, &child_self, root_href, root_title, &child_dir, Some((self_href.to_string(), self_title.clone())))?;
+    }
+    Ok(())
+}
+
+fn write_theme(
+    result: &ThemeResult,
+    self_href: &str,
+    root_href: &str,
+    root_title: &str,
+    dest: &Path,
+    parent: (String, String),
+) -> Result<()> {
+    let mut catalog = result.theme_catalog.clone();
+    catalog.links.clear();
+    catalog.links.push(mk_link("root", root_href, Some("application/json"), Some(root_title)));
+    for l in &result.theme_extra_links {
+        catalog.links.push(l.clone());
+    }
+    for (type_name, _, _, _) in &result.type_collections {
+        let href = format!("{}/{}/collection.json", strip_last(self_href), type_name);
+        catalog.links.push(mk_link("child", &href, Some("application/json"), Some(type_name)));
+    }
+    catalog.links.push(mk_link("parent", &parent.0, Some("application/json"), Some(&parent.1)));
+    catalog.links.push(mk_link("self", self_href, Some("application/json"), None));
+
+    stac_io::write(dest.join("catalog.json"), catalog)?;
+
+    let theme_title = result
+        .theme_catalog
+        .title
+        .clone()
+        .unwrap_or_else(|| result.theme_name.clone());
+    for (type_name, collection, items, extra_links) in &result.type_collections {
+        let coll_dir = dest.join(type_name);
+        std::fs::create_dir_all(&coll_dir)?;
+        let coll_href = format!("{}/{}/collection.json", strip_last(self_href), type_name);
+        write_collection(collection, items, extra_links, &coll_href, root_href, root_title, &coll_dir, (self_href.to_string(), theme_title.clone()))?;
+    }
+    Ok(())
+}
+
+fn write_collection(
+    collection: &Collection,
+    items: &[Item],
+    extra_links: &[Link],
+    self_href: &str,
+    root_href: &str,
+    root_title: &str,
+    dest: &Path,
+    parent: (String, String),
+) -> Result<()> {
+    let mut coll = collection.clone();
+    coll.links.clear();
+    coll.links.push(mk_link("root", root_href, Some("application/json"), Some(root_title)));
+    for l in extra_links {
+        coll.links.push(l.clone());
+    }
+    for it in items {
+        let href = format!("{}/{}/{}.json", strip_last(self_href), it.id, it.id);
+        coll.links.push(mk_link("item", &href, Some("application/geo+json"), None));
+    }
+    coll.links.push(mk_link("parent", &parent.0, Some("application/json"), Some(&parent.1)));
+    coll.links.push(mk_link("self", self_href, Some("application/json"), None));
+
+    stac_io::write(dest.join("collection.json"), coll)?;
+
+    let type_name = collection.id.clone();
+    for it in items {
+        let item_dir = dest.join(&it.id);
+        std::fs::create_dir_all(&item_dir)?;
+        let item_self = format!("{}/{}/{}.json", strip_last(self_href), it.id, it.id);
+        write_item(it, &item_self, root_href, root_title, &item_dir, self_href, &type_name)?;
+    }
+    Ok(())
+}
+
+fn write_item(
+    item: &Item,
+    self_href: &str,
+    root_href: &str,
+    root_title: &str,
+    dest: &Path,
+    collection_href: &str,
+    collection_id: &str,
+) -> Result<()> {
+    let mut it = item.clone();
+    it.links.clear();
+    it.links.push(mk_link("root", root_href, Some("application/json"), Some(root_title)));
+    it.links.push(mk_link("collection", collection_href, Some("application/json"), Some(collection_id)));
+    it.links.push(mk_link("parent", collection_href, Some("application/json"), Some(collection_id)));
+    it.links.push(mk_link("self", self_href, Some("application/json"), None));
+    it.collection = Some(collection_id.to_string());
+
+    stac_io::write(dest.join(format!("{}.json", item.id)), it)?;
+    Ok(())
+}
+
+fn mk_link(rel: &str, href: &str, media_type: Option<&str>, title: Option<&str>) -> Link {
+    let mut l = Link::new(href, rel);
+    l.r#type = media_type.map(str::to_string);
+    l.title = title.map(str::to_string);
+    l
+}
+
+fn strip_last(href: &str) -> String {
+    if let Some(idx) = href.rfind('/') {
+        href[..idx].to_string()
+    } else {
+        href.to_string()
+    }
+}
+
+/// Build the top-level `Overture Releases` catalog (multi-release path).
+pub async fn build_top_catalog(
+    bucket: &Bucket,
+    ids: &[String],
+    _root_href: &str,
+    debug: bool,
+    workers: usize,
+    output: &Path,
+) -> Result<ReleaseCatalog> {
+    let mut children: Vec<ReleaseCatalog> = Vec::new();
+    for (idx, release) in ids.iter().enumerate() {
+        let title = if idx == 0 {
+            "Latest Overture Release".to_string()
+        } else {
+            format!("{release} Overture Release")
+        };
+        let mut child = build_single_release(bucket, release, "", &title, debug, workers, output).await?;
+        if idx == 0 {
+            child.catalog.additional_fields.insert("latest".into(), json!(true));
+            child.extra_child_fields.insert("latest".into(), json!(true));
+        }
+        children.push(child);
+    }
+
+    let mut top = Catalog::new("Overture Releases", "All Overture Releases");
+    top.title = Some("Overture Releases".into());
+    if let Some(latest) = ids.first() {
+        top.additional_fields.insert("latest".into(), json!(latest));
+    }
+    let manifest = registry::create_manifest(bucket).await.unwrap_or(json!([]));
+    top.additional_fields.insert(
+        "registry".into(),
+        json!({"path": "s3://overturemaps-us-west-2/registry", "manifest": manifest}),
+    );
+
+    Ok(ReleaseCatalog {
+        catalog: top,
+        bundles: Vec::new(),
+        neighbor_links: Vec::new(),
+        sub_children: children,
+        extra_child_fields: serde_json::Map::new(),
+    })
+}
+
+impl Bucket {
+    pub fn clone_ref(&self) -> Self {
+        Self {
+            store: Arc::clone(&self.store),
+            name: self.name.clone(),
+        }
+    }
+}
+
+fn write_collections_parquet(path: &Path, items: Vec<Item>) -> Result<()> {
+    if items.is_empty() {
+        // Match pystac behavior: emit an empty parquet placeholder so directory shape holds.
+        std::fs::write(path, b"")?;
+        return Ok(());
+    }
+    let coll: ItemCollection = items.into();
+    coll.into_geoparquet_path(path, WriterOptions::default())
+        .with_context(|| format!("write {}", path.display()))?;
+    Ok(())
+}

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,0 +1,6 @@
+pub mod catalog;
+pub mod parquet_io;
+pub mod pmtiles;
+pub mod registry;
+pub mod s3;
+pub mod theme;

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -1,0 +1,107 @@
+use anyhow::{Context, Result, bail};
+use clap::Parser;
+use regex::Regex;
+use std::path::PathBuf;
+use tracing_subscriber::EnvFilter;
+
+use overture_stac_rs::{
+    catalog::{
+        build_single_release, build_top_catalog, link_neighbor_releases, list_release_ids,
+        save_absolute_published,
+    },
+    s3::new_public_bucket,
+};
+
+const PROD_ROOT_HREF: &str = "https://stac.overturemaps.org";
+
+/// Generate a STAC Index for Overture Maps Data from the public release bucket.
+#[derive(Parser, Debug)]
+#[command(version, about)]
+struct Cli {
+    /// Output path for Catalog
+    #[arg(long, default_value = "public_releases")]
+    output: PathBuf,
+
+    /// Debug flag to only generate 1 item per collection
+    #[arg(long, default_value_t = false)]
+    debug: bool,
+
+    /// Number of parallel workers (default: 4)
+    #[arg(long, default_value_t = 4)]
+    workers: usize,
+
+    /// Release version to generate STAC for (e.g. 2026-05-20.0). When omitted, all releases are processed.
+    #[arg(long)]
+    release: Option<String>,
+
+    /// Schema version for the release (e.g. 1.17.0). Required when --release is provided.
+    #[arg(long = "schema-version")]
+    schema_version: Option<String>,
+
+    /// Public root URL the catalog will be hosted at, used to build absolute
+    /// 'self' links. Override for staging/testing, e.g. https://staging.overturemaps.org/stac/pr/123.
+    #[arg(long = "root-href", default_value = PROD_ROOT_HREF)]
+    root_href: String,
+}
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")))
+        .init();
+
+    let cli = Cli::parse();
+
+    let root_href = cli.root_href.trim_end_matches('/').to_string();
+
+    if cli.release.is_some() && cli.schema_version.is_none() {
+        bail!("--schema-version is required when --release is provided");
+    }
+
+    if let Some(r) = &cli.release {
+        let re = Regex::new(r"^\d{4}-\d{2}-\d{2}\.\d+$").unwrap();
+        if !re.is_match(r) {
+            bail!("--release must be in format YYYY-MM-DD.N (e.g. 2026-05-20.0)");
+        }
+    }
+    if let Some(s) = &cli.schema_version {
+        let re = Regex::new(r"^\d+\.\d+\.\d+$").unwrap();
+        if !re.is_match(s) {
+            bail!("--schema-version must be in format X.Y.Z (e.g. 1.17.0)");
+        }
+    }
+
+    std::fs::create_dir_all(&cli.output)
+        .with_context(|| format!("creating output dir {}", cli.output.display()))?;
+
+    let bucket = new_public_bucket("overturemaps-us-west-2", "us-west-2")?;
+
+    if let Some(release) = cli.release {
+        let schema = cli.schema_version.unwrap();
+        let title = format!("{release} Overture Release");
+
+        let mut catalog = build_single_release(
+            &bucket,
+            &release,
+            &schema,
+            &title,
+            cli.debug,
+            cli.workers,
+            &cli.output,
+        )
+        .await?;
+
+        let ids = list_release_ids(&bucket, "release").await?;
+        link_neighbor_releases(&mut catalog, &ids, &root_href);
+
+        let dest = cli.output.join(&release);
+        save_absolute_published(&catalog, &format!("{root_href}/{release}"), &dest)?;
+        return Ok(());
+    }
+
+    // Multi-release path.
+    let ids = list_release_ids(&bucket, "release").await?;
+    let top = build_top_catalog(&bucket, &ids, &root_href, cli.debug, cli.workers, &cli.output).await?;
+    save_absolute_published(&top, &root_href, &cli.output)?;
+    Ok(())
+}

--- a/rust/src/parquet_io.rs
+++ b/rust/src/parquet_io.rs
@@ -1,0 +1,140 @@
+//! Read GeoParquet fragment metadata from S3 — bbox from the `geo` metadata blob, plus
+//! `num_rows`, `num_row_groups`, and the column names for `table:columns`.
+//!
+//! Fast path: `ParquetMetaDataReader::load_via_suffix_and_finish` issues one ranged suffix GET
+//! (`Range: bytes=-N`), and only issues a second GET if the encoded metadata is larger than the
+//! prefetch. Avoids a separate HEAD and the full stream-builder setup.
+
+use anyhow::{Context, Result, bail};
+use bytes::Bytes;
+use futures::future::{BoxFuture, FutureExt};
+use object_store::{GetOptions, GetRange, ObjectStore, path::Path as ObjPath};
+use parquet::arrow::parquet_to_arrow_schema;
+use parquet::arrow::async_reader::{MetadataFetch, MetadataSuffixFetch};
+use parquet::errors::{ParquetError, Result as ParquetResult};
+use std::ops::Range;
+use parquet::file::metadata::ParquetMetaDataReader;
+use serde_json::Value;
+use std::sync::{Arc, OnceLock};
+use tokio::sync::Semaphore;
+
+/// Cap total concurrent parquet metadata GETs across the whole process. Combined with
+/// theme-level and type-level fan-out we can otherwise open thousands of concurrent S3
+/// connections and hit object_store's retry-timeout wall.
+static GLOBAL_PARQUET_LIMIT: OnceLock<Semaphore> = OnceLock::new();
+
+fn parquet_limit() -> &'static Semaphore {
+    GLOBAL_PARQUET_LIMIT.get_or_init(|| Semaphore::new(64))
+}
+
+pub struct FragmentInfo {
+    pub path: String,
+    pub num_rows: i64,
+    pub num_row_groups: i64,
+    pub bbox: [f64; 4],
+    pub column_names: Vec<String>,
+    pub geoparquet_version: Option<String>,
+}
+
+pub async fn read_fragment(store: Arc<dyn ObjectStore>, key: &str) -> Result<FragmentInfo> {
+    let _permit = parquet_limit().acquire().await.expect("global parquet semaphore poisoned");
+    let path = ObjPath::from(key);
+    let mut fetch = SuffixFetch { store: &store, path };
+    let meta = ParquetMetaDataReader::new()
+        .load_via_suffix_and_finish(&mut fetch)
+        .await
+        .with_context(|| format!("load parquet metadata for {key}"))?;
+    let file_meta = meta.file_metadata();
+
+    let arrow_schema = parquet_to_arrow_schema(file_meta.schema_descr(), file_meta.key_value_metadata())
+        .with_context(|| format!("parquet -> arrow schema for {key}"))?;
+    let column_names: Vec<String> = arrow_schema
+        .fields()
+        .iter()
+        .map(|f| f.name().to_string())
+        .collect();
+
+    let kv = file_meta.key_value_metadata();
+    let geo_str = kv
+        .and_then(|kvs| kvs.iter().find(|kv| kv.key == "geo"))
+        .and_then(|kv| kv.value.clone())
+        .ok_or_else(|| anyhow::anyhow!("no `geo` metadata in {key}"))?;
+    let geo: Value = serde_json::from_str(&geo_str)
+        .with_context(|| format!("parse geo metadata in {key}"))?;
+
+    let geometry = geo
+        .get("columns")
+        .and_then(|c| c.get("geometry"))
+        .ok_or_else(|| anyhow::anyhow!("no columns.geometry in geo metadata"))?;
+    let bbox_arr = geometry
+        .get("bbox")
+        .and_then(|b| b.as_array())
+        .ok_or_else(|| anyhow::anyhow!("no bbox in geometry metadata"))?;
+    if bbox_arr.len() != 4 {
+        bail!("bbox length != 4 in {key}");
+    }
+    let mut bbox = [0f64; 4];
+    for (i, v) in bbox_arr.iter().enumerate() {
+        bbox[i] = v
+            .as_f64()
+            .ok_or_else(|| anyhow::anyhow!("bbox coord {i} not a number"))?;
+    }
+
+    let geoparquet_version = geo.get("version").and_then(|v| v.as_str()).map(str::to_owned);
+
+    Ok(FragmentInfo {
+        path: key.to_string(),
+        num_rows: file_meta.num_rows(),
+        num_row_groups: meta.num_row_groups() as i64,
+        bbox,
+        column_names,
+        geoparquet_version,
+    })
+}
+
+struct SuffixFetch<'a> {
+    store: &'a Arc<dyn ObjectStore>,
+    path: ObjPath,
+}
+
+impl<'a> MetadataFetch for &mut SuffixFetch<'a> {
+    fn fetch(&mut self, range: Range<u64>) -> BoxFuture<'_, ParquetResult<Bytes>> {
+        let store = self.store;
+        let path = self.path.clone();
+        async move {
+            let opts = GetOptions {
+                range: Some(GetRange::Bounded(range)),
+                ..GetOptions::default()
+            };
+            let resp = store
+                .get_opts(&path, opts)
+                .await
+                .map_err(|e| ParquetError::General(format!("object_store bounded GET: {e}")))?;
+            resp.bytes()
+                .await
+                .map_err(|e| ParquetError::General(format!("object_store body: {e}")))
+        }
+        .boxed()
+    }
+}
+
+impl<'a> MetadataSuffixFetch for &mut SuffixFetch<'a> {
+    fn fetch_suffix(&mut self, suffix: usize) -> BoxFuture<'_, ParquetResult<Bytes>> {
+        let store = self.store;
+        let path = self.path.clone();
+        async move {
+            let opts = GetOptions {
+                range: Some(GetRange::Suffix(suffix as u64)),
+                ..GetOptions::default()
+            };
+            let resp = store
+                .get_opts(&path, opts)
+                .await
+                .map_err(|e| ParquetError::General(format!("object_store suffix GET: {e}")))?;
+            resp.bytes()
+                .await
+                .map_err(|e| ParquetError::General(format!("object_store body: {e}")))
+        }
+        .boxed()
+    }
+}

--- a/rust/src/pmtiles.rs
+++ b/rust/src/pmtiles.rs
@@ -1,0 +1,32 @@
+//! Discover available PMTiles files for a release, mirroring OvertureRelease._get_available_pmtiles.
+
+use anyhow::Result;
+use std::collections::BTreeMap;
+
+use crate::s3::{Bucket, list_top_level};
+
+pub async fn discover(bucket_extras: &Bucket, release: &str) -> BTreeMap<String, String> {
+    // The Python code catches all exceptions and warns; we do the same — a missing tiles
+    // directory is not an error.
+    let prefix = format!("tiles/{release}");
+    match list_top_level(bucket_extras, &prefix).await {
+        Ok(names) => names
+            .into_iter()
+            .filter(|n| n.ends_with(".pmtiles"))
+            .map(|n| {
+                let base = n.trim_end_matches(".pmtiles").to_string();
+                let full = format!("overturemaps-extras-us-west-2/{prefix}/{n}");
+                (base, full)
+            })
+            .collect(),
+        Err(e) => {
+            tracing::warn!("Couldn't find PMTiles for release {release}: {e}");
+            BTreeMap::new()
+        }
+    }
+}
+
+pub fn discover_sync(_release: &str) -> Result<BTreeMap<String, String>> {
+    // Not used; discover() is async. Placeholder for future sync callers.
+    Ok(BTreeMap::new())
+}

--- a/rust/src/registry.rs
+++ b/rust/src/registry.rs
@@ -1,0 +1,91 @@
+//! Port of `RegistryManifest.create_manifest`.
+//!
+//! Reads every parquet under `overturemaps-us-west-2/registry/`, pulls the max value of the
+//! `id` column from the LAST row group's statistics of the first fragment, and returns a
+//! `[[filename, max_id], ...]` list sorted by max_id.
+
+use anyhow::{Context, Result};
+use object_store::{ObjectStore, ObjectStoreExt, path::Path as ObjPath};
+use parquet::arrow::ParquetRecordBatchStreamBuilder;
+#[allow(deprecated)]
+use parquet::arrow::async_reader::ParquetObjectReader;
+use parquet::file::statistics::Statistics;
+use serde_json::{Value, json};
+use std::sync::Arc;
+
+use crate::s3::{Bucket, list_all};
+
+pub async fn create_manifest(bucket: &Bucket) -> Result<Value> {
+    let prefix = "registry";
+    tracing::info!("Scanning registry path: {}/{}", bucket.name, prefix);
+
+    let files = list_all(bucket, prefix).await?;
+    let parquet_files: Vec<String> = files
+        .into_iter()
+        .filter(|k| k.ends_with(".parquet"))
+        .collect();
+    tracing::info!("Found {} parquet files in registry", parquet_files.len());
+
+    let mut entries: Vec<(String, String)> = Vec::new();
+
+    for key in parquet_files {
+        match read_max_id(&bucket.store, &key).await {
+            Ok(Some(max_id)) => {
+                let filename = key.trim_start_matches("registry/").to_string();
+                let last = filename.rsplit('/').next().unwrap_or(&filename).to_string();
+                tracing::info!("{last}: Max ID: {max_id}");
+                entries.push((filename, max_id));
+            }
+            Ok(None) => tracing::warn!("No 'id' column or stats in {key}"),
+            Err(e) => tracing::error!("Error processing {key}: {e}"),
+        }
+    }
+
+    entries.sort_by(|a, b| a.1.cmp(&b.1));
+    tracing::info!("Total files processed: {}", entries.len());
+
+    let arr: Vec<Value> = entries
+        .into_iter()
+        .map(|(f, id)| json!([f, id]))
+        .collect();
+    Ok(Value::Array(arr))
+}
+
+#[allow(deprecated)]
+async fn read_max_id(store: &Arc<dyn ObjectStore>, key: &str) -> Result<Option<String>> {
+    let path = ObjPath::from(key);
+    let meta = store.head(&path).await.with_context(|| format!("HEAD {key}"))?;
+    let reader = ParquetObjectReader::new(Arc::clone(store), path).with_file_size(meta.size);
+    let builder = ParquetRecordBatchStreamBuilder::new(reader)
+        .await
+        .with_context(|| format!("open parquet {key}"))?;
+    let pq_meta = builder.metadata();
+    let file_meta = pq_meta.file_metadata();
+    let schema = file_meta.schema_descr();
+
+    let id_col_idx = (0..schema.num_columns()).find(|i| schema.column(*i).name() == "id");
+    let Some(idx) = id_col_idx else { return Ok(None) };
+
+    if pq_meta.num_row_groups() == 0 {
+        return Ok(None);
+    }
+    let last_rg = pq_meta.row_group(pq_meta.num_row_groups() - 1);
+    let col = last_rg.column(idx);
+    let Some(stats) = col.statistics() else { return Ok(None) };
+    Ok(extract_max(stats))
+}
+
+fn extract_max(stats: &Statistics) -> Option<String> {
+    match stats {
+        Statistics::ByteArray(s) => s.max_opt().map(|b| String::from_utf8_lossy(b.data()).into_owned()),
+        Statistics::FixedLenByteArray(s) => {
+            s.max_opt().map(|b| String::from_utf8_lossy(b.data()).into_owned())
+        }
+        Statistics::Int32(s) => s.max_opt().map(|v| v.to_string()),
+        Statistics::Int64(s) => s.max_opt().map(|v| v.to_string()),
+        Statistics::Int96(s) => s.max_opt().map(|v| v.to_string()),
+        Statistics::Boolean(s) => s.max_opt().map(|v| v.to_string()),
+        Statistics::Float(s) => s.max_opt().map(|v| v.to_string()),
+        Statistics::Double(s) => s.max_opt().map(|v| v.to_string()),
+    }
+}

--- a/rust/src/s3.rs
+++ b/rust/src/s3.rs
@@ -1,0 +1,58 @@
+//! Anonymous S3 access to the public Overture bucket. Mirrors `pyarrow.fs.S3FileSystem(anonymous=True)`.
+
+use anyhow::{Context, Result};
+use object_store::aws::AmazonS3Builder;
+use object_store::{ObjectStore, path::Path};
+use std::sync::Arc;
+
+/// Handle to a single anonymous public S3 bucket.
+pub struct Bucket {
+    pub store: Arc<dyn ObjectStore>,
+    pub name: String,
+}
+
+pub fn new_public_bucket(bucket: &str, region: &str) -> Result<Bucket> {
+    let store = AmazonS3Builder::new()
+        .with_bucket_name(bucket)
+        .with_region(region)
+        .with_skip_signature(true)
+        .build()
+        .with_context(|| format!("building anonymous S3 client for {bucket}"))?;
+    Ok(Bucket {
+        store: Arc::new(store),
+        name: bucket.to_string(),
+    })
+}
+
+/// List "top-level" entries under `prefix`, returning the last path segment for each — the
+/// same shape pyarrow's `FileSelector(prefix)` returns: directories and files immediately under it.
+pub async fn list_top_level(bucket: &Bucket, prefix: &str) -> Result<Vec<String>> {
+    let p = Path::from(prefix);
+    let result = bucket.store.list_with_delimiter(Some(&p)).await
+        .with_context(|| format!("listing {prefix} in {}", bucket.name))?;
+    let mut out = Vec::new();
+    for pref in result.common_prefixes {
+        if let Some(name) = pref.parts().last() {
+            out.push(name.as_ref().to_string());
+        }
+    }
+    for obj in result.objects {
+        if let Some(name) = obj.location.parts().last() {
+            out.push(name.as_ref().to_string());
+        }
+    }
+    Ok(out)
+}
+
+/// Recursively list all object keys under `prefix`.
+pub async fn list_all(bucket: &Bucket, prefix: &str) -> Result<Vec<String>> {
+    use futures::stream::StreamExt;
+    let p = Path::from(prefix);
+    let mut stream = bucket.store.list(Some(&p));
+    let mut out = Vec::new();
+    while let Some(meta) = stream.next().await {
+        let meta = meta.with_context(|| format!("listing {prefix}"))?;
+        out.push(meta.location.to_string());
+    }
+    Ok(out)
+}

--- a/rust/src/theme.rs
+++ b/rust/src/theme.rs
@@ -1,0 +1,369 @@
+//! Per-theme processing — port of `process_theme_worker` in `overture_stac.py`.
+//!
+//! Returns typed `stac` values (Catalog per theme, Collection per type, Item per fragment)
+//! plus the manifest features destined for `manifest.geojson`.
+
+use anyhow::Result;
+use chrono::{DateTime, SecondsFormat, Utc};
+use serde_json::{Map as JsonMap, Value, json};
+use stac::{Bbox, Catalog, Collection, Extent, Item, Link, SpatialExtent, TemporalExtent};
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use crate::parquet_io::{FragmentInfo, read_fragment};
+use crate::s3::{Bucket, list_top_level};
+
+pub const ITEM_STAC_EXTENSIONS: &[&str] = &[
+    "https://stac-extensions.github.io/storage/v2.0.0/schema.json",
+    "https://stac-extensions.github.io/alternate-assets/v1.2.0/schema.json",
+];
+
+pub const TABLE_EXTENSION: &str = "https://stac-extensions.github.io/table/v1.2.0/schema.json";
+
+pub fn type_license(type_name: &str) -> Option<&'static str> {
+    match type_name {
+        "bathymetry" => Some("CC0-1.0"),
+        "land_cover" => Some("CC-BY-4.0"),
+        "infrastructure" | "land" | "land_use" | "water" | "building" | "building_part"
+        | "division" | "division_area" | "division_boundary" | "segment" | "connector" => {
+            Some("ODbL-1.0")
+        }
+        "place" | "address" => Some("other"),
+        _ => None,
+    }
+}
+
+pub struct ThemeResult {
+    pub theme_name: String,
+    pub theme_catalog: Catalog,
+    /// Extra links (e.g. pmtiles) that the save walk attaches after `root` and before children.
+    pub theme_extra_links: Vec<Link>,
+    pub manifest_items: Vec<Value>,
+    /// Ordered per-type: (type_name, collection, items, extra_links).
+    pub type_collections: Vec<(String, Collection, Vec<Item>, Vec<Link>)>,
+}
+
+pub async fn process_theme(
+    bucket: &Bucket,
+    theme_key: &str,
+    release: &str,
+    debug: bool,
+    release_datetime: DateTime<Utc>,
+    available_pmtiles: &BTreeMap<String, String>,
+) -> Result<ThemeResult> {
+    let theme_name = theme_key
+        .rsplit_once('=')
+        .map(|(_, n)| n)
+        .unwrap_or(theme_key)
+        .to_string();
+    tracing::info!("Processing Theme: {theme_name}");
+
+    let mut theme_catalog = Catalog::new(&theme_name, format!("Overture's {theme_name} theme"));
+    theme_catalog.title = Some(theme_name.clone());
+
+    let mut theme_extra_links = Vec::new();
+    if available_pmtiles.contains_key(&theme_name) {
+        tracing::info!("Adding PMTiles link for theme {theme_name}");
+        let mut link = Link::new(
+            format!("https://tiles.overturemaps.org/{release}/{theme_name}.pmtiles"),
+            "pmtiles",
+        );
+        link.r#type = Some("application/vnd.pmtiles".into());
+        link.title = Some("PMTiles".into());
+        theme_extra_links.push(link);
+    }
+
+    // List types under this theme prefix and fan out concurrently (bounded).
+    use futures::stream::{StreamExt, TryStreamExt};
+    const TYPES_PER_THEME: usize = 4;
+    let type_keys = list_top_level(bucket, theme_key).await?;
+    let theme_key_owned = theme_key.to_string();
+    let bucket_owned = Arc::new(bucket.clone_ref());
+    let type_futs = type_keys.into_iter().map(|type_key| {
+        let bucket = Arc::clone(&bucket_owned);
+        let theme_key = theme_key_owned.clone();
+        async move { process_type(&bucket, &theme_key, &type_key, debug, release_datetime).await }
+    });
+    let per_type: Vec<PerType> = futures::stream::iter(type_futs)
+        .buffer_unordered(TYPES_PER_THEME)
+        .try_collect()
+        .await?;
+
+    let mut manifest_items = Vec::new();
+    let mut type_collections = Vec::new();
+    for pt in per_type {
+        manifest_items.extend(pt.manifest_items);
+        type_collections.push((pt.type_name, pt.collection, pt.items, pt.extra_links));
+    }
+
+    Ok(ThemeResult {
+        theme_name,
+        theme_catalog,
+        theme_extra_links,
+        manifest_items,
+        type_collections,
+    })
+}
+
+struct PerType {
+    type_name: String,
+    collection: Collection,
+    items: Vec<Item>,
+    manifest_items: Vec<Value>,
+    extra_links: Vec<Link>,
+}
+
+async fn process_type(
+    bucket: &Bucket,
+    theme_key: &str,
+    type_key: &str,
+    debug: bool,
+    release_datetime: DateTime<Utc>,
+) -> Result<PerType> {
+    let type_full = format!("{theme_key}/{type_key}");
+    let type_name = type_key
+        .rsplit_once('=')
+        .map(|(_, n)| n)
+        .unwrap_or(type_key)
+        .to_string();
+    tracing::info!("Opening Type: {type_name}");
+
+    let mut fragments_keys = list_top_level(bucket, &type_full).await?;
+    fragments_keys.retain(|f| f.ends_with(".parquet"));
+    fragments_keys.sort();
+    if debug {
+        fragments_keys.truncate(3);
+    }
+    let total_fragments = fragments_keys.len();
+    let full_keys: Vec<String> = fragments_keys
+        .iter()
+        .map(|f| format!("{type_full}/{f}"))
+        .collect();
+
+    // Concurrent fragment metadata reads, bounded to keep S3 fanout in check.
+    use futures::stream::{StreamExt, TryStreamExt};
+    const FRAGMENT_CONCURRENCY: usize = 32;
+    let store_arc = bucket.store.clone();
+    let fragment_futs: Vec<_> = full_keys
+        .clone()
+        .into_iter()
+        .enumerate()
+        .map(|(idx, key)| {
+            let store = Arc::clone(&store_arc);
+            async move {
+                let info = read_fragment(store, &key).await?;
+                Ok::<(usize, FragmentInfo), anyhow::Error>((idx, info))
+            }
+        })
+        .collect();
+    let mut fragments: Vec<(usize, FragmentInfo)> = futures::stream::iter(fragment_futs)
+        .buffer_unordered(FRAGMENT_CONCURRENCY)
+        .try_collect()
+        .await?;
+    fragments.sort_by_key(|(i, _)| *i);
+
+    let mut items: Vec<Item> = Vec::with_capacity(fragments.len());
+    let mut manifest_items: Vec<Value> = Vec::with_capacity(fragments.len());
+    let mut columns_hint: Option<Vec<String>> = None;
+    let mut geoparquet_version: Option<String> = None;
+    let mut total_row_count: i64 = 0;
+
+    for (idx, fragment) in &fragments {
+        if idx % 10 == 0 || *idx == total_fragments - 1 {
+            let dir_last = full_keys[*idx].split('/').rev().nth(1).unwrap_or("?");
+            tracing::info!(" [ {dir_last} : {}/{total_fragments} fragments ]", idx + 1);
+        }
+        if columns_hint.is_none() {
+            columns_hint = Some(fragment.column_names.clone());
+        }
+        if geoparquet_version.is_none() {
+            geoparquet_version = fragment.geoparquet_version.clone();
+        }
+        total_row_count += fragment.num_rows;
+
+        let [xmin, ymin, xmax, ymax] = fragment.bbox;
+        let filename = fragment.path.rsplit('/').next().unwrap_or("");
+        let rel_path = fragment.path.clone();
+        let item_id = filename.split('-').nth(1).unwrap_or(filename).to_string();
+
+        let geojson_bbox = json!({
+            "type": "Polygon",
+            "coordinates": [[
+                [xmin, ymin],
+                [xmax, ymin],
+                [xmax, ymax],
+                [xmin, ymax],
+                [xmin, ymin],
+            ]]
+        });
+
+        let mut item = Item::new(&item_id);
+        item.extensions = ITEM_STAC_EXTENSIONS.iter().map(|s| s.to_string()).collect();
+        item.geometry = Some(serde_json::from_value(geojson_bbox.clone())?);
+        item.bbox = Some(Bbox::new(xmin, ymin, xmax, ymax));
+
+        // Properties: num_rows, num_row_groups, storage:schemes, datetime.
+        let props = &mut item.properties.additional_fields;
+        props.insert("num_rows".into(), json!(fragment.num_rows));
+        props.insert("num_row_groups".into(), json!(fragment.num_row_groups));
+        props.insert(
+            "storage:schemes".into(),
+            json!({
+                "aws": {
+                    "type": "aws-s3",
+                    "platform": "https://{bucket}.s3.{region}.amazonaws.com",
+                    "bucket": "overturemaps-us-west-2",
+                    "region": "us-west-2",
+                    "requester_pays": false,
+                },
+                "azure": {
+                    "type": "ms-azure",
+                    "platform": "https://{account}.blob.core.windows.net",
+                    "account": "overturemapswestus2",
+                    "requester_pays": false,
+                },
+            }),
+        );
+        let iso = release_datetime.to_rfc3339_opts(SecondsFormat::Secs, true);
+        item.properties.datetime = Some(iso.parse().ok().unwrap_or_default());
+
+        // Assets
+        let mut aws_asset = stac::Asset::new(format!(
+            "https://overturemaps-us-west-2.s3.us-west-2.amazonaws.com/{rel_path}"
+        ));
+        aws_asset.r#type = Some("application/vnd.apache.parquet".into());
+        aws_asset.title = Some("GeoParquet on AWS S3".into());
+        aws_asset.description = Some(
+            "Zstd-compressed GeoParquet in the overturemaps-us-west-2 bucket, served over HTTPS."
+                .into(),
+        );
+        aws_asset.roles = vec!["data".into()];
+        aws_asset
+            .additional_fields
+            .insert("storage:refs".into(), json!(["aws"]));
+        aws_asset
+            .additional_fields
+            .insert("alternate:name".into(), json!("HTTPS"));
+        aws_asset.additional_fields.insert(
+            "alternate".into(),
+            json!({
+                "s3": {
+                    "href": format!("s3://overturemaps-us-west-2/{}", fragment.path),
+                    "alternate:name": "S3",
+                    "description": "Access the files via regular Amazon AWS S3 tooling.",
+                    "roles": ["data"],
+                }
+            }),
+        );
+        item.assets.insert("aws".into(), aws_asset);
+
+        let mut azure_asset = stac::Asset::new(format!(
+            "https://overturemapswestus2.blob.core.windows.net/{rel_path}"
+        ));
+        azure_asset.r#type = Some("application/vnd.apache.parquet".into());
+        azure_asset.title = Some("GeoParquet on Azure Blob Storage".into());
+        azure_asset.description = Some(
+            "Zstd-compressed GeoParquet in the overturemapswestus2 storage account (West US 2), served over HTTPS.".into(),
+        );
+        azure_asset.roles = vec!["data".into()];
+        azure_asset
+            .additional_fields
+            .insert("storage:refs".into(), json!(["azure"]));
+        item.assets.insert("azure".into(), azure_asset);
+
+        manifest_items.push(json!({
+            "type": "Feature",
+            "properties": {
+                "ovt_type": type_name,
+                "rel_path": rel_path,
+            },
+            "geometry": geojson_bbox,
+            "bbox": [xmin, ymin, xmax, ymax],
+        }));
+
+        items.push(item);
+    }
+
+    // Build Collection with extent from item bboxes (matches pystac's SpatialExtent(bboxes=[...])).
+    let extent = Extent {
+        spatial: SpatialExtent {
+            bbox: items
+                .iter()
+                .filter_map(|it| it.bbox.as_ref().cloned())
+                .collect(),
+        },
+        temporal: TemporalExtent {
+            interval: vec![[None, None]],
+        },
+        additional_fields: JsonMap::new(),
+    };
+
+    let mut collection = Collection::new(&type_name, format!("Overture's {type_name} collection"));
+    collection.title = Some(type_name.clone());
+    collection.extent = extent;
+    collection.extensions = vec![TABLE_EXTENSION.into()];
+
+    let extras = &mut collection.additional_fields;
+    let columns_json: Vec<Value> = columns_hint
+        .as_ref()
+        .map(|cols| cols.iter().map(|n| json!({"name": n})).collect())
+        .unwrap_or_default();
+    extras.insert("table:columns".into(), Value::Array(columns_json));
+    extras.insert("table:primary_geometry".into(), json!("geometry"));
+    extras.insert("table:row_count".into(), json!(total_row_count));
+    extras.insert(
+        "geoparquet:version".into(),
+        geoparquet_version
+            .as_ref()
+            .map(|v| json!(v))
+            .unwrap_or(Value::Null),
+    );
+    if !debug {
+        extras.insert("features".into(), json!(total_row_count));
+    }
+
+    if let Some(lic) = type_license(&type_name) {
+        collection.license = lic.into();
+    }
+
+    if !items.is_empty() {
+        let rows: Vec<i64> = items
+            .iter()
+            .filter_map(|i| i.properties.additional_fields.get("num_rows"))
+            .filter_map(|v| v.as_i64())
+            .collect();
+        let groups: Vec<i64> = items
+            .iter()
+            .filter_map(|i| i.properties.additional_fields.get("num_row_groups"))
+            .filter_map(|v| v.as_i64())
+            .collect();
+        let summaries = json!({
+            "num_rows": {"minimum": rows.iter().min().unwrap_or(&0), "maximum": rows.iter().max().unwrap_or(&0)},
+            "num_row_groups": {"minimum": groups.iter().min().unwrap_or(&0), "maximum": groups.iter().max().unwrap_or(&0)},
+        });
+        let mut summaries_map = JsonMap::new();
+        if let Value::Object(m) = summaries {
+            summaries_map = m;
+        }
+        collection.summaries = serde_json::from_value(Value::Object(summaries_map)).unwrap_or_default();
+    }
+
+    // License link (only for "other"-licensed types).
+    let mut extra_links = Vec::new();
+    if type_license(&type_name) == Some("other") {
+        let mut l = Link::new(
+            "https://docs.overturemaps.org/attribution/",
+            "license",
+        );
+        l.title = Some("Overture Maps Attribution and Licensing".into());
+        extra_links.push(l);
+    }
+
+    Ok(PerType {
+        type_name,
+        collection,
+        items,
+        manifest_items,
+        extra_links,
+    })
+}


### PR DESCRIPTION
## Results

**Full-mode compare on `2026-07-22.0` (all fragments, all themes):**

|          | Wall clock | Outcome                                                    |
| -------- | ---------- | ---------------------------------------------------------- |
| Python   | 606.3s     | 996 JSON files                                             |
| **Rust** | **143.6s** | 996 JSON files — **4.2× faster**, **996/996 semantic parity** |

Parity check compares dicts recursively with arrays sorted (so permuted link lists and manifest features match set-wise).

## Bonus: resilience

A prior full-mode Python run **crashed at 558s** on a single transient S3 `ListObjectsV2` timeout — `pyarrow.fs.S3FileSystem` doesn't retry list ops. Rust `object_store` retried and finished. Worth patching Python-side either way.

## Stack

`stac 0.17` + `stac-io 0.3` (both with `geoparquet` feature) + `object_store 0.13` + `parquet 59` + `tokio`.

## Known non-parity items (all semantic-equivalent)

- Field order & whitespace in JSON differ — `stac` crate's Serialize impls vs pystac.
- `2026-07-22.0/catalog.json` child link order and `manifest.geojson` feature order differ — Python's `ProcessPoolExecutor.as_completed` is non-deterministic; Rust sorts alphabetically.
- `collections.parquet` column layout differs — both are valid stac-geoparquet (same 39 rows / 13 cols), Python and Rust `stac-geoparquet` writers structure the flat columns differently.

## Reproduce

```sh
just rs-compare 1.18.0 2026-07-22.0            # debug (3 fragments per type)
just rs-compare 1.18.0 2026-07-22.0 CARGS=''   # full
```