### PR TITLE
[BUG] Always write root `catalog.json` for all modes

### DIFF
--- a/src/overture_stac/cli.py
+++ b/src/overture_stac/cli.py
@@ -9,12 +9,14 @@ import pystac
 
 from overture_stac.overture_stac import (
     OvertureRelease,
+    build_root_catalog,
     link_neighbor_releases,
     list_release_ids,
 )
 from overture_stac.registry_manifest import RegistryManifest
 
 PROD_ROOT_HREF = "https://stac.overturemaps.org"
+REGISTRY_S3_PATH = "s3://overturemaps-us-west-2/registry"
 
 
 def main():
@@ -96,9 +98,10 @@ def main():
         )
         title = f"{args.release} Overture Release"
         this_release.build_release_catalog(title=title, max_workers=args.workers)
+        release_ids = list_release_ids(this_release.filesystem)
         link_neighbor_releases(
             this_release.release_catalog,
-            list_release_ids(this_release.filesystem),
+            release_ids,
             root_href,
         )
         this_release.release_catalog.normalize_hrefs(f"{root_href}/{args.release}/")
@@ -106,25 +109,23 @@ def main():
             catalog_type=pystac.CatalogType.ABSOLUTE_PUBLISHED,
             dest_href=str(output / args.release),
         )
+
+        # Refresh root so `latest` reflects the current bucket.
+        build_root_catalog(
+            output=output,
+            root_href=root_href,
+            release_ids=release_ids,
+            registry={
+                "path": REGISTRY_S3_PATH,
+                "manifest": RegistryManifest().create_manifest(),
+            },
+        )
         return
 
     filesystem = fs.S3FileSystem(anonymous=True, region="us-west-2")
-    available_releases = filesystem.get_file_info(
-        fs.FileSelector("overturemaps-us-west-2/release")
-    )
+    release_ids = list_release_ids(filesystem)
 
-    overture_releases_catalog = pystac.Catalog(
-        id="Overture Releases",
-        title="Overture Releases",
-        description="All Overture Releases",
-    )
-
-    release_catalogs: list[pystac.Catalog] = []
-    for idx, release_info in enumerate(
-        sorted(available_releases, key=lambda p: p.path, reverse=True)
-    ):
-        release = release_info.path.split("/")[-1]
-
+    for idx, release in enumerate(release_ids):
         title: str = (
             f"{release} Overture Release" if idx > 0 else "Latest Overture Release"
         )
@@ -135,32 +136,26 @@ def main():
             output=output,
             debug=args.debug,
         )
-
         this_release.build_release_catalog(title=title, max_workers=args.workers)
 
-        child = overture_releases_catalog.add_child(
-            child=this_release.release_catalog, title=title
-        )
-        release_catalogs.append(this_release.release_catalog)
-
+        link_neighbor_releases(this_release.release_catalog, release_ids, root_href)
         if idx == 0:
-            child.extra_fields = {"latest": True}
             this_release.release_catalog.extra_fields["latest"] = True
-            overture_releases_catalog.extra_fields = {"latest": release}
 
-    release_ids = [c.id for c in release_catalogs]
-    for cat in release_catalogs:
-        link_neighbor_releases(cat, release_ids, root_href)
+        this_release.release_catalog.normalize_hrefs(f"{root_href}/{release}/")
+        this_release.release_catalog.save(
+            catalog_type=pystac.CatalogType.ABSOLUTE_PUBLISHED,
+            dest_href=str(output / release),
+        )
 
-    registry_manifest = RegistryManifest()
-    overture_releases_catalog.extra_fields["registry"] = {
-        "path": "s3://overturemaps-us-west-2/registry",
-        "manifest": registry_manifest.create_manifest(),
-    }
-
-    overture_releases_catalog.normalize_hrefs(f"{root_href}/")
-    overture_releases_catalog.save(
-        catalog_type=pystac.CatalogType.ABSOLUTE_PUBLISHED, dest_href=str(output)
+    build_root_catalog(
+        output=output,
+        root_href=root_href,
+        release_ids=release_ids,
+        registry={
+            "path": REGISTRY_S3_PATH,
+            "manifest": RegistryManifest().create_manifest(),
+        },
     )
 
 

--- a/src/overture_stac/overture_stac.py
+++ b/src/overture_stac/overture_stac.py
@@ -22,6 +22,53 @@ def list_release_ids(filesystem: fs.S3FileSystem) -> list[str]:
     return sorted((r.path.split("/")[-1] for r in info), reverse=True)
 
 
+def build_root_catalog(
+    output: Path,
+    root_href: str,
+    release_ids: list[str],
+    registry: Optional[dict] = None,
+) -> pystac.Catalog:
+    """Write the root 'Overture Releases' catalog to ``output/catalog.json``.
+
+    Function sorts ``release_ids`` lexicographically (release ids are
+    YYYY-MM-DD.N) and marks the newest as ``latest``.
+    """
+    root = root_href.rstrip("/")
+    output.mkdir(parents=True, exist_ok=True)
+
+    release_ids = sorted(release_ids, reverse=True)
+
+    catalog = pystac.Catalog(
+        id="Overture Releases",
+        title="Overture Releases",
+        description="All Overture Releases",
+    )
+
+    for idx, release_id in enumerate(release_ids):
+        link = pystac.Link(
+            rel="child",
+            target=f"{root}/{release_id}/catalog.json",
+            media_type="application/json",
+            title=(
+                "Latest Overture Release"
+                if idx == 0
+                else f"{release_id} Overture Release"
+            ),
+        )
+        if idx == 0:
+            link.extra_fields = {"latest": True}
+        catalog.add_link(link)
+
+    if release_ids:
+        catalog.extra_fields["latest"] = release_ids[0]
+    if registry is not None:
+        catalog.extra_fields["registry"] = registry
+
+    catalog.set_self_href(f"{root}/catalog.json")
+    catalog.save_object(include_self_link=True, dest_href=str(output / "catalog.json"))
+    return catalog
+
+
 def link_neighbor_releases(
     catalog: pystac.Catalog,
     all_release_ids: list[str],

--- a/tests/setup_test_catalog.py
+++ b/tests/setup_test_catalog.py
@@ -24,7 +24,7 @@ from pathlib import Path
 import pyarrow.fs as fs
 import pystac
 
-from overture_stac.overture_stac import OvertureRelease
+from overture_stac.overture_stac import OvertureRelease, build_root_catalog
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -38,6 +38,24 @@ SCHEMA_VERSION_MAPPING: dict[str, str] = {
 }
 
 DEFAULT_PORT = 8888
+
+# Stub older release so the fixture exercises the multi-release root.
+STUB_OLDER_RELEASE_ID = "2000-01-01.0"
+
+
+def _write_stub_release_catalog(
+    output_dir: Path, release_id: str, root_href: str
+) -> None:
+    """Minimal per-release catalog.json so the root's child link resolves."""
+    stub_dir = output_dir / release_id
+    stub_dir.mkdir(parents=True, exist_ok=True)
+    stub = pystac.Catalog(
+        id=release_id,
+        title=f"{release_id} Overture Release",
+        description=f"Synthetic older release ({release_id}) for CI fixture.",
+    )
+    stub.set_self_href(f"{root_href.rstrip('/')}/{release_id}/catalog.json")
+    stub.save_object(include_self_link=True, dest_href=str(stub_dir / "catalog.json"))
 
 
 def discover_releases() -> list[str]:
@@ -112,39 +130,24 @@ def build_test_catalog(
 
     title = f"Test Release {release}"
     overture_release.build_release_catalog(title=title, max_workers=workers)
-
-    # Create root catalog to match CLI structure
-    root_catalog = pystac.Catalog(
-        id="Overture Releases",
-        title="Overture Releases",
-        description="All Overture Releases (Test)",
-    )
-
-    child = root_catalog.add_child(
-        child=overture_release.release_catalog,
-        title=title,
-    )
-    child.extra_fields = {"latest": True}
     overture_release.release_catalog.extra_fields["latest"] = True
-    root_catalog.extra_fields = {"latest": release}
-
-    # # Add registry manifest
-    # try:
-    #     registry_manifest = RegistryManifest()
-    #     root_catalog.extra_fields["registry"] = {
-    #         "path": "s3://overturemaps-us-west-2/registry",
-    #         "manifest": registry_manifest.create_manifest(),
-    #     }
-    # except Exception as e:
-    #     logger.warning(f"Could not create registry manifest: {e}")
-
-    # Normalize and save. Strip any trailing slash from user input first so
-    # the appended "/" below always joins with exactly one slash.
-    logger.info(f"Saving catalog to {output_dir}...")
-    root_catalog.normalize_hrefs(root_href.rstrip("/") + "/")
-    root_catalog.save(
+    overture_release.release_catalog.normalize_hrefs(
+        f"{root_href.rstrip('/')}/{release}/"
+    )
+    overture_release.release_catalog.save(
         catalog_type=pystac.CatalogType.ABSOLUTE_PUBLISHED,
-        dest_href=str(output_dir),
+        dest_href=str(output_dir / release),
+    )
+
+    _write_stub_release_catalog(output_dir, STUB_OLDER_RELEASE_ID, root_href)
+
+    # Same function the CLI uses — fixture doubles as a live test.
+    logger.info(f"Saving root catalog to {output_dir}...")
+    build_root_catalog(
+        output=output_dir,
+        root_href=root_href,
+        release_ids=[release, STUB_OLDER_RELEASE_ID],
+        registry=None,
     )
 
     catalog_path = output_dir / release

--- a/tests/test_build_root_catalog.py
+++ b/tests/test_build_root_catalog.py
@@ -1,0 +1,95 @@
+"""Unit tests for build_root_catalog."""
+
+import json
+from pathlib import Path
+
+from overture_stac.overture_stac import build_root_catalog
+
+ROOT = "https://stac.overturemaps.org"
+
+
+def _read_root(output: Path) -> dict:
+    with open(output / "catalog.json") as f:
+        return json.load(f)
+
+
+def _children(doc: dict) -> list[dict]:
+    return [link for link in doc["links"] if link["rel"] == "child"]
+
+
+class TestBuildRootCatalog:
+    def test_writes_catalog_json_at_output_root(self, tmp_path):
+        build_root_catalog(tmp_path, ROOT, ["2026-08-05.0", "2026-07-22.0"])
+        assert (tmp_path / "catalog.json").exists()
+
+    def test_root_has_expected_identity(self, tmp_path):
+        build_root_catalog(tmp_path, ROOT, ["2026-08-05.0"])
+        doc = _read_root(tmp_path)
+        assert doc["type"] == "Catalog"
+        assert doc["id"] == "Overture Releases"
+        assert doc["title"] == "Overture Releases"
+
+    def test_child_link_per_release_in_order(self, tmp_path):
+        ids = ["2026-08-05.0", "2026-07-22.0", "2026-06-17.0"]
+        build_root_catalog(tmp_path, ROOT, ids)
+        children = _children(_read_root(tmp_path))
+        assert [c["href"] for c in children] == [
+            f"{ROOT}/{i}/catalog.json" for i in ids
+        ]
+
+    def test_input_order_is_normalised_to_newest_first(self, tmp_path):
+        """Caller may pass any order; function sorts newest-first internally."""
+        build_root_catalog(
+            tmp_path, ROOT, ["2026-06-17.0", "2026-08-05.0", "2026-07-22.0"]
+        )
+        doc = _read_root(tmp_path)
+        assert [c["href"] for c in _children(doc)] == [
+            f"{ROOT}/2026-08-05.0/catalog.json",
+            f"{ROOT}/2026-07-22.0/catalog.json",
+            f"{ROOT}/2026-06-17.0/catalog.json",
+        ]
+        assert doc["latest"] == "2026-08-05.0"
+
+    def test_newest_child_link_titled_latest(self, tmp_path):
+        build_root_catalog(tmp_path, ROOT, ["2026-08-05.0", "2026-07-22.0"])
+        children = _children(_read_root(tmp_path))
+        assert children[0]["title"] == "Latest Overture Release"
+        assert children[0]["latest"] is True
+        assert children[1]["title"] == "2026-07-22.0 Overture Release"
+        assert "latest" not in children[1]
+
+    def test_root_extra_fields_latest_matches_newest_id(self, tmp_path):
+        build_root_catalog(tmp_path, ROOT, ["2026-08-05.0", "2026-07-22.0"])
+        assert _read_root(tmp_path)["latest"] == "2026-08-05.0"
+
+    def test_registry_embedded_when_provided(self, tmp_path):
+        registry = {"path": "s3://bucket/registry", "manifest": [["file.parquet", "z"]]}
+        build_root_catalog(tmp_path, ROOT, ["2026-08-05.0"], registry=registry)
+        assert _read_root(tmp_path)["registry"] == registry
+
+    def test_registry_omitted_when_none(self, tmp_path):
+        build_root_catalog(tmp_path, ROOT, ["2026-08-05.0"])
+        assert "registry" not in _read_root(tmp_path)
+
+    def test_empty_release_list_still_writes_root(self, tmp_path):
+        build_root_catalog(tmp_path, ROOT, [])
+        doc = _read_root(tmp_path)
+        assert _children(doc) == []
+        assert "latest" not in doc
+
+    def test_trailing_slash_on_root_href_is_normalised(self, tmp_path):
+        build_root_catalog(tmp_path, ROOT + "/", ["2026-08-05.0"])
+        children = _children(_read_root(tmp_path))
+        assert children[0]["href"] == f"{ROOT}/2026-08-05.0/catalog.json"
+
+    def test_self_link_uses_absolute_root_href(self, tmp_path):
+        build_root_catalog(tmp_path, ROOT, ["2026-08-05.0"])
+        doc = _read_root(tmp_path)
+        self_links = [link for link in doc["links"] if link["rel"] == "self"]
+        assert len(self_links) == 1
+        assert self_links[0]["href"] == f"{ROOT}/catalog.json"
+
+    def test_output_dir_is_created_if_missing(self, tmp_path):
+        target = tmp_path / "does" / "not" / "exist"
+        build_root_catalog(target, ROOT, ["2026-08-05.0"])
+        assert (target / "catalog.json").exists()

--- a/tests/test_e2e_stac_catalog.py
+++ b/tests/test_e2e_stac_catalog.py
@@ -29,23 +29,22 @@ def get_test_data_dir() -> Path:
 
 
 def find_release_name() -> str | None:
-    """
-    Find a release directory name in the test data directory.
-
-    Returns:
-        Release name (e.g., '2025-01-22.0'), or None if not found
-    """
+    """Newest real release id; skips the stub the fixture also writes."""
     data_dir = get_test_data_dir()
     if not data_dir.exists():
         return None
 
-    for item in data_dir.iterdir():
-        if item.is_dir() and item.name[0].isdigit():
-            catalog_path = item / "catalog.json"
-            if catalog_path.exists():
-                return item.name
-
-    return None
+    candidates = sorted(
+        (
+            item.name
+            for item in data_dir.iterdir()
+            if item.is_dir()
+            and item.name[0].isdigit()
+            and (item / "catalog.json").exists()
+        ),
+        reverse=True,
+    )
+    return candidates[0] if candidates else None
 
 
 def is_port_in_use(port: int) -> bool:
@@ -200,6 +199,28 @@ class TestRootCatalogValidation:
     def test_root_catalog_has_latest_field(self, root_catalog):
         """Test that the root catalog has a 'latest' field."""
         assert "latest" in root_catalog.extra_fields
+
+    @pytest.mark.integration
+    def test_root_catalog_has_two_children(self, root_catalog):
+        """Real release + stub."""
+        children = list(root_catalog.get_child_links())
+        assert len(children) == 2
+
+    @pytest.mark.integration
+    def test_root_catalog_children_ordered_newest_first(self, root_catalog):
+        """Newest-first ordering drives `latest`."""
+        titles = [link.title for link in root_catalog.get_child_links()]
+        assert titles[0] == "Latest Overture Release"
+
+    @pytest.mark.integration
+    def test_root_catalog_latest_matches_newest_child(self, root_catalog, release_name):
+        assert root_catalog.extra_fields["latest"] == release_name
+
+    @pytest.mark.integration
+    def test_root_catalog_newest_child_link_marked_latest(self, root_catalog):
+        """Consumers walking links (not extra_fields) rely on this."""
+        first = next(iter(root_catalog.get_child_links()))
+        assert first.extra_fields.get("latest") is True
 
 
 class TestReleaseCatalogValidation:


### PR DESCRIPTION
Closes https://github.com/OvertureMaps/stac/issues/102

## Summary

Extracts the root-catalog composition out of `cli.py` into a public library function `build_root_catalog`, and calls it from both `--release` and walk-all branches so every `gen-stac` run leaves a correct root `catalog.json` on disk. Callers pass any `release_ids` order; the function sorts newest-first and marks `latest`.

## Why

Root composition was CLI-internal, so importers of `overture-stac` (notably the DAG-side publisher) couldn't reproduce it. Promoting it to a library function lets both the CLI and downstream publishers keep `latest` and the release listing in sync with the bucket on every publish, not just on nightly walks.

## Tests

- 11 unit tests for `build_root_catalog` (shape, ordering, `latest` marking, registry embed, empty list, self-link, trailing-slash normalisation).
- Fixture in `setup_test_catalog.py` now writes a stub older release alongside the real one and composes the root via `build_root_catalog` — the CI e2e suite dogfoods it end-to-end.
- 4 new e2e assertions on the root: exactly two children, newest-first ordering, `latest` matches newest child id, newest child link carries `latest: true`.

Registry embed is preserved byte-for-byte (verified via diff against pre-change baseline).

## Follow-up

DAG-side wiring tracked in OvertureMaps/tf-data-platform#4867.