### PR TITLE
[FEATURE] Add scheduled workflow to publish the STAC catalog to prod

### DIFF
--- a/.github/workflows/publish-catalog.yaml
+++ b/.github/workflows/publish-catalog.yaml
@@ -89,7 +89,12 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Sync to S3
-        run: aws s3 sync --delete . s3://overturemaps-extras-us-west-2/stac/
+        uses: OvertureMaps/workflows/.github/actions/s5cmd@1d64352771111dac23f75453caaa560e67bf8bc2 # main
+        with:
+          command: sync
+          flags: --delete
+          source: ./
+          destination: s3://overturemaps-extras-us-west-2/stac/
 
       - name: Configure AWS credentials (CloudFront invalidation, cross-account) 🔐
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
@@ -123,7 +128,12 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Sync to S3
-        run: aws s3 sync --delete . s3://overturemaps-extras-us-west-2/stac/
+        uses: OvertureMaps/workflows/.github/actions/s5cmd@1d64352771111dac23f75453caaa560e67bf8bc2 # main
+        with:
+          command: sync
+          flags: --delete
+          source: ./
+          destination: s3://overturemaps-extras-us-west-2/stac/
 
       - name: Configure AWS credentials (CloudFront invalidation, cross-account) 🔐
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3

--- a/.github/workflows/publish-catalog.yaml
+++ b/.github/workflows/publish-catalog.yaml
@@ -1,0 +1,133 @@
+---
+# Publishes the production STAC catalog (stac.overturemaps.org). Rebuilds the
+# catalog for every release currently in the public bucket, validates it, then
+# mirrors it to the public S3 bucket and busts the CloudFront cache. Replaces
+# tf-data-platform's `release_publish_stac_dag` (see OvertureMaps/stac#107).
+name: Publish STAC Catalog
+
+on:
+  schedule:
+    - cron: "0 0 * * *" # daily at midnight UTC, same cadence as the old DAG
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build & Validate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write # required for actions/upload-artifact
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version-file: .python-version
+
+      - name: Install UV
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+
+      - name: Install dependencies
+        run: |
+          uv pip install --system -e .
+
+      - name: Build STAC Catalog
+        run: gen-stac --output public_releases
+
+      - name: Validate STAC Catalog
+        uses: OvertureMaps/stac-check-action@3b06576bbf96c8d172f627c1639ac128f4fd7e38 # v1.0.0
+        with:
+          stac-check-version: "1.14.0"
+          file: ./public_releases/catalog.json
+          recursive: "true"
+          fast-linting: "true"
+          job-summary: "true"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: stac-catalog
+          path: public_releases
+
+  # Split into scheduled vs. manual jobs (rather than one job with a
+  # conditional `environment:`) because the OIDC trust policy on the S3 role
+  # keys off the job's claims: `ref:refs/heads/main` for the scheduled run,
+  # `environment:manual-publish` for workflow_dispatch. A single job can't
+  # carry both claims, and GitHub Actions doesn't support conditionally
+  # omitting `environment:` on one job.
+  publish-scheduled:
+    name: Publish (scheduled)
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name == 'schedule'
+    permissions:
+      id-token: write # required for OIDC token exchange with AWS
+      actions: read # required for actions/download-artifact
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: stac-catalog
+
+      - name: Configure AWS credentials (S3 push) 🔐
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
+        with:
+          role-to-assume: arn:aws:iam::913550007193:role/stac-publish-oidc-overturemaps
+          aws-region: us-west-2
+
+      - name: Sync to S3
+        run: aws s3 sync --delete . s3://overturemaps-extras-us-west-2/stac/
+
+      - name: Configure AWS credentials (CloudFront invalidation, cross-account) 🔐
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
+        with:
+          role-to-assume: arn:aws:iam::763944545891:role/cloudfront-invalidator
+          role-chaining: true
+          aws-region: us-west-2
+
+      - name: Bust the cache
+        run: aws cloudfront create-invalidation --distribution-id E209PEWSOCNO5D --paths "/*"
+
+  publish-manual:
+    name: Publish (manual)
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name == 'workflow_dispatch'
+    environment: manual-publish # requires reviewer approval; see OvertureMaps/omf-github-terraform#121
+    permissions:
+      id-token: write # required for OIDC token exchange with AWS
+      actions: read # required for actions/download-artifact
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: stac-catalog
+
+      - name: Configure AWS credentials (S3 push) 🔐
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
+        with:
+          role-to-assume: arn:aws:iam::913550007193:role/stac-publish-oidc-overturemaps
+          aws-region: us-west-2
+
+      - name: Sync to S3
+        run: aws s3 sync --delete . s3://overturemaps-extras-us-west-2/stac/
+
+      - name: Configure AWS credentials (CloudFront invalidation, cross-account) 🔐
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
+        with:
+          role-to-assume: arn:aws:iam::763944545891:role/cloudfront-invalidator
+          role-chaining: true
+          aws-region: us-west-2
+
+      - name: Bust the cache
+        run: aws cloudfront create-invalidation --distribution-id E209PEWSOCNO5D --paths "/*"

--- a/.github/workflows/publish-catalog.yaml
+++ b/.github/workflows/publish-catalog.yaml
@@ -19,6 +19,7 @@ env:
   AWS_REGION: us-west-2
   STAC_PUBLISH_ROLE_ARN: arn:aws:iam::913550007193:role/stac-publish-oidc-overturemaps
   CLOUDFRONT_INVALIDATOR_ROLE_ARN: arn:aws:iam::763944545891:role/cloudfront-invalidator
+  CATALOG_OUTPUT_DIR: public_releases
 
 jobs:
   build:
@@ -46,13 +47,13 @@ jobs:
           uv pip install --system -e .
 
       - name: Build STAC Catalog
-        run: gen-stac --output public_releases
+        run: gen-stac --output "$CATALOG_OUTPUT_DIR"
 
       - name: Validate STAC Catalog
         uses: OvertureMaps/stac-check-action@3b06576bbf96c8d172f627c1639ac128f4fd7e38 # v1.0.0
         with:
           stac-check-version: "1.14.0"
-          file: ./public_releases/catalog.json
+          file: ${{ env.CATALOG_OUTPUT_DIR }}/catalog.json
           recursive: "true"
           fast-linting: "true"
           job-summary: "true"
@@ -61,7 +62,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: stac-catalog
-          path: public_releases
+          path: ${{ env.CATALOG_OUTPUT_DIR }}
 
   publish:
     name: Publish

--- a/.github/workflows/publish-catalog.yaml
+++ b/.github/workflows/publish-catalog.yaml
@@ -89,7 +89,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Sync to S3
-        uses: OvertureMaps/workflows/.github/actions/s5cmd@1d64352771111dac23f75453caaa560e67bf8bc2 # main
+        uses: OvertureMaps/workflows/.github/actions/s5cmd@main # zizmor: ignore[unpinned-uses] intentionally track main
         with:
           command: sync
           flags: --delete
@@ -128,7 +128,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Sync to S3
-        uses: OvertureMaps/workflows/.github/actions/s5cmd@1d64352771111dac23f75453caaa560e67bf8bc2 # main
+        uses: OvertureMaps/workflows/.github/actions/s5cmd@main # zizmor: ignore[unpinned-uses] intentionally track main
         with:
           command: sync
           flags: --delete

--- a/.github/workflows/publish-catalog.yaml
+++ b/.github/workflows/publish-catalog.yaml
@@ -64,11 +64,10 @@ jobs:
           path: public_releases
 
   # Split into scheduled vs. manual jobs (rather than one job with a
-  # conditional `environment:`) because the OIDC trust policy on the S3 role
-  # keys off the job's claims: `ref:refs/heads/main` for the scheduled run,
-  # `environment:manual-publish` for workflow_dispatch. A single job can't
-  # carry both claims, and GitHub Actions doesn't support conditionally
-  # omitting `environment:` on one job.
+  # conditional `environment:`) because manual publishes need to go through
+  # the `manual-publish` environment's required reviewer approval, and
+  # GitHub Actions doesn't support conditionally omitting `environment:` on
+  # one job.
   publish-scheduled:
     name: Publish (scheduled)
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-catalog.yaml
+++ b/.github/workflows/publish-catalog.yaml
@@ -1,8 +1,7 @@
 ---
 # Publishes the production STAC catalog (stac.overturemaps.org). Rebuilds the
 # catalog for every release currently in the public bucket, validates it, then
-# mirrors it to the public S3 bucket and busts the CloudFront cache. Replaces
-# tf-data-platform's `release_publish_stac_dag` (see OvertureMaps/stac#107).
+# mirrors it to the public S3 bucket and busts the CloudFront cache.
 name: Publish STAC Catalog
 
 on:
@@ -15,6 +14,11 @@ permissions: {}
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false
+
+env:
+  AWS_REGION: us-west-2
+  STAC_PUBLISH_ROLE_ARN: arn:aws:iam::913550007193:role/stac-publish-oidc-overturemaps
+  CLOUDFRONT_INVALIDATOR_ROLE_ARN: arn:aws:iam::763944545891:role/cloudfront-invalidator
 
 jobs:
   build:
@@ -82,8 +86,8 @@ jobs:
       - name: Configure AWS credentials (S3 push) 🔐
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
-          role-to-assume: arn:aws:iam::913550007193:role/stac-publish-oidc-overturemaps
-          aws-region: us-west-2
+          role-to-assume: ${{ env.STAC_PUBLISH_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
 
       - name: Sync to S3
         run: aws s3 sync --delete . s3://overturemaps-extras-us-west-2/stac/
@@ -91,9 +95,9 @@ jobs:
       - name: Configure AWS credentials (CloudFront invalidation, cross-account) 🔐
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
-          role-to-assume: arn:aws:iam::763944545891:role/cloudfront-invalidator
+          role-to-assume: ${{ env.CLOUDFRONT_INVALIDATOR_ROLE_ARN }}
           role-chaining: true
-          aws-region: us-west-2
+          aws-region: ${{ env.AWS_REGION }}
 
       - name: Bust the cache
         run: aws cloudfront create-invalidation --distribution-id E209PEWSOCNO5D --paths "/*"
@@ -103,7 +107,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     if: github.event_name == 'workflow_dispatch'
-    environment: manual-publish # requires reviewer approval; see OvertureMaps/omf-github-terraform#121
+    environment: manual-publish # requires reviewer approval
     permissions:
       id-token: write # required for OIDC token exchange with AWS
       actions: read # required for actions/download-artifact
@@ -116,8 +120,8 @@ jobs:
       - name: Configure AWS credentials (S3 push) 🔐
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
-          role-to-assume: arn:aws:iam::913550007193:role/stac-publish-oidc-overturemaps
-          aws-region: us-west-2
+          role-to-assume: ${{ env.STAC_PUBLISH_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
 
       - name: Sync to S3
         run: aws s3 sync --delete . s3://overturemaps-extras-us-west-2/stac/
@@ -125,9 +129,9 @@ jobs:
       - name: Configure AWS credentials (CloudFront invalidation, cross-account) 🔐
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
-          role-to-assume: arn:aws:iam::763944545891:role/cloudfront-invalidator
+          role-to-assume: ${{ env.CLOUDFRONT_INVALIDATOR_ROLE_ARN }}
           role-chaining: true
-          aws-region: us-west-2
+          aws-region: ${{ env.AWS_REGION }}
 
       - name: Bust the cache
         run: aws cloudfront create-invalidation --distribution-id E209PEWSOCNO5D --paths "/*"

--- a/.github/workflows/publish-catalog.yaml
+++ b/.github/workflows/publish-catalog.yaml
@@ -20,6 +20,7 @@ env:
   STAC_PUBLISH_ROLE_ARN: arn:aws:iam::913550007193:role/stac-publish-oidc-overturemaps
   CLOUDFRONT_INVALIDATOR_ROLE_ARN: arn:aws:iam::763944545891:role/cloudfront-invalidator
   CATALOG_OUTPUT_DIR: public_releases
+  CLOUDFRONT_DISTRIBUTION_ID: E209PEWSOCNO5D
 
 jobs:
   build:
@@ -102,4 +103,4 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Bust the cache
-        run: aws cloudfront create-invalidation --distribution-id E209PEWSOCNO5D --paths "/*"
+        run: aws cloudfront create-invalidation --distribution-id "$CLOUDFRONT_DISTRIBUTION_ID" --paths "/*"

--- a/.github/workflows/publish-catalog.yaml
+++ b/.github/workflows/publish-catalog.yaml
@@ -80,6 +80,7 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: stac-catalog
+          path: ${{ env.CATALOG_OUTPUT_DIR }}
 
       - name: Configure AWS credentials (S3 push) 🔐
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
@@ -92,7 +93,7 @@ jobs:
         with:
           command: sync
           flags: --delete
-          source: ./
+          source: ${{ env.CATALOG_OUTPUT_DIR }}/
           destination: s3://overturemaps-extras-us-west-2/stac/
 
       - name: Configure AWS credentials (CloudFront invalidation, cross-account) 🔐

--- a/.github/workflows/publish-catalog.yaml
+++ b/.github/workflows/publish-catalog.yaml
@@ -6,7 +6,7 @@ name: Publish STAC Catalog
 
 on:
   schedule:
-    - cron: "0 0 * * *" # daily at midnight UTC, same cadence as the old DAG
+    - cron: "0 */6 * * *" # every 6 hours
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/publish-catalog.yaml
+++ b/.github/workflows/publish-catalog.yaml
@@ -63,55 +63,13 @@ jobs:
           name: stac-catalog
           path: public_releases
 
-  # Split into scheduled vs. manual jobs (rather than one job with a
-  # conditional `environment:`) because manual publishes need to go through
-  # the `manual-publish` environment's required reviewer approval, and
-  # GitHub Actions doesn't support conditionally omitting `environment:` on
-  # one job.
-  publish-scheduled:
-    name: Publish (scheduled)
+  publish:
+    name: Publish
     runs-on: ubuntu-latest
     needs: build
-    if: github.event_name == 'schedule'
-    permissions:
-      id-token: write # required for OIDC token exchange with AWS
-      actions: read # required for actions/download-artifact
-    steps:
-      - name: Download artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: stac-catalog
-
-      - name: Configure AWS credentials (S3 push) 🔐
-        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
-        with:
-          role-to-assume: ${{ env.STAC_PUBLISH_ROLE_ARN }}
-          aws-region: ${{ env.AWS_REGION }}
-
-      - name: Sync to S3
-        uses: OvertureMaps/workflows/.github/actions/s5cmd@main # zizmor: ignore[unpinned-uses] intentionally track main
-        with:
-          command: sync
-          flags: --delete
-          source: ./
-          destination: s3://overturemaps-extras-us-west-2/stac/
-
-      - name: Configure AWS credentials (CloudFront invalidation, cross-account) 🔐
-        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
-        with:
-          role-to-assume: ${{ env.CLOUDFRONT_INVALIDATOR_ROLE_ARN }}
-          role-chaining: true
-          aws-region: ${{ env.AWS_REGION }}
-
-      - name: Bust the cache
-        run: aws cloudfront create-invalidation --distribution-id E209PEWSOCNO5D --paths "/*"
-
-  publish-manual:
-    name: Publish (manual)
-    runs-on: ubuntu-latest
-    needs: build
-    if: github.event_name == 'workflow_dispatch'
-    environment: manual-publish # requires reviewer approval
+    # Empty string evaluates to "no environment" for a job-level `environment:`,
+    # so the schedule trigger skips the manual-publish gate entirely.
+    environment: ${{ github.event_name == 'workflow_dispatch' && 'manual-publish' || '' }} # manual-publish requires reviewer approval
     permissions:
       id-token: write # required for OIDC token exchange with AWS
       actions: read # required for actions/download-artifact

--- a/README.md
+++ b/README.md
@@ -6,25 +6,9 @@
 ![PyPI - Version](https://img.shields.io/pypi/v/overture-stac)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-This repo owns two things: `overture-stac`, the CLI that generates STAC catalogs for public Overture releases, and the production catalog at `stac.overturemaps.org`, built and published by this repo's own GitHub Actions workflow.
+This repo owns two things: `overture-stac`, the CLI that generates STAC catalogs for public Overture releases, and the production catalog at `stac.overturemaps.org`. See [`docs/architecture.md`](https://github.com/OvertureMaps/stac/blob/main/docs/architecture.md) for how the catalog gets built and published.
 
 **[Browse the catalog](https://radiantearth.github.io/stac-browser/#/external/stac.overturemaps.org/catalog.json?.language=en)**
-
-## Production catalog
-
-`publish-catalog.yaml` rebuilds the catalog every 6 hours from every release currently in the public bucket, validates it with `stac-check-action`, then mirrors it to `stac.overturemaps.org` and busts the CloudFront cache. See [`docs/architecture.md`](./docs/architecture.md) for how the publish step spans two AWS accounts and why.
-
-It also runs on manual dispatch, gated behind the `manual-publish` environment's required reviewer approval.
-
-### Slack notifications
-
-To get a Slack channel notified of publish runs, use GitHub's [Slack app](https://slack.github.com/) from that channel:
-
-```
-/github subscribe OvertureMaps/stac workflows:{"name":"Publish STAC Catalog"}
-```
-
-This is a one-time, per-channel setup step; it isn't configured by the workflow itself.
 
 ## The `overture-stac` CLI
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Manual dispatches of that workflow will publish to https://test.pypi.org/project
 
 ## Publishing the STAC catalog
 
-`publish-catalog.yaml` rebuilds the production STAC catalog daily and mirrors it to `stac.overturemaps.org`. It also runs on manual dispatch, gated behind the `manual-publish` environment's required reviewer approval.
+`publish-catalog.yaml` rebuilds the production STAC catalog every 6 hours and mirrors it to `stac.overturemaps.org`. It also runs on manual dispatch, gated behind the `manual-publish` environment's required reviewer approval.
 
 ### Slack notifications
 

--- a/README.md
+++ b/README.md
@@ -6,17 +6,35 @@
 ![PyPI - Version](https://img.shields.io/pypi/v/overture-stac)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-Generate STAC catalogs for all public Overture Maps releases.
+This repo owns two things: `overture-stac`, the CLI that generates STAC catalogs for public Overture Maps releases, and the production catalog at `stac.overturemaps.org`, built and published by this repo's own GitHub Actions workflow.
 
 **[Browse the catalog](https://radiantearth.github.io/stac-browser/#/external/stac.overturemaps.org/catalog.json?.language=en)**
 
-## Setup
+## Production catalog
+
+`publish-catalog.yaml` rebuilds the catalog every 6 hours from every release currently in the public bucket, validates it with `stac-check-action`, then mirrors it to `stac.overturemaps.org` and busts the CloudFront cache.
+
+It also runs on manual dispatch, gated behind the `manual-publish` environment's required reviewer approval.
+
+### Slack notifications
+
+To get a Slack channel notified of publish runs, use GitHub's [Slack app](https://slack.github.com/) from that channel:
+
+```
+/github subscribe OvertureMaps/stac workflows:{"name":"Publish STAC Catalog"}
+```
+
+This is a one-time, per-channel setup step; it isn't configured by the workflow itself.
+
+## The `overture-stac` CLI
+
+### Setup
 
 ```bash
 uv sync
 ```
 
-## Usage
+### Usage
 
 ```bash
 gen-stac --output ./releases
@@ -36,23 +54,9 @@ uv run ruff format . && uv run ruff check . && uv run pytest
 
 A [`justfile`](./justfile) collects the common development commands. Install [just](https://github.com/casey/just) with `brew install just` and run `just` to see the available recipes. For instance, `just check` runs the same lint, format, and test steps as CI.
 
-## Release
+## Releasing the package to PyPI
 
 Once a GitHub Release has been created (and the pyproject.toml contains a version bump),
 `publish-pypi.yml` is triggered to publish to PyPI.
 
 Manual dispatches of that workflow will publish to https://test.pypi.org/project/overture-stac/ for debugging and validation.
-
-## Publishing the STAC catalog
-
-`publish-catalog.yaml` rebuilds the production STAC catalog every 6 hours and mirrors it to `stac.overturemaps.org`. It also runs on manual dispatch, gated behind the `manual-publish` environment's required reviewer approval.
-
-### Slack notifications
-
-To get a Slack channel notified of publish runs, use GitHub's [Slack app](https://slack.github.com/) from that channel:
-
-```
-/github subscribe OvertureMaps/stac workflows:{"name":"Publish STAC Catalog"}
-```
-
-This is a one-time, per-channel setup step; it isn't configured by the workflow itself.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Overture STAC
 
 [![CI](https://github.com/OvertureMaps/stac/actions/workflows/ci.yaml/badge.svg)](https://github.com/OvertureMaps/stac/actions/workflows/ci.yaml)
+[![Publish STAC Catalog](https://github.com/OvertureMaps/stac/actions/workflows/publish-catalog.yaml/badge.svg)](https://github.com/OvertureMaps/stac/actions/workflows/publish-catalog.yaml)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
 ![PyPI - Version](https://img.shields.io/pypi/v/overture-stac)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
@@ -41,3 +42,17 @@ Once a GitHub Release has been created (and the pyproject.toml contains a versio
 `publish-pypi.yml` is triggered to publish to PyPI.
 
 Manual dispatches of that workflow will publish to https://test.pypi.org/project/overture-stac/ for debugging and validation.
+
+## Publishing the STAC catalog
+
+`publish-catalog.yaml` rebuilds the production STAC catalog daily and mirrors it to `stac.overturemaps.org`. It also runs on manual dispatch, gated behind the `manual-publish` environment's required reviewer approval.
+
+### Slack notifications
+
+To get a Slack channel notified of publish runs, use GitHub's [Slack app](https://slack.github.com/) from that channel:
+
+```
+/github subscribe OvertureMaps/stac workflows:{"name":"Publish STAC Catalog"}
+```
+
+This is a one-time, per-channel setup step; it isn't configured by the workflow itself.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This repo owns two things: `overture-stac`, the CLI that generates STAC catalogs
 
 ## Production catalog
 
-`publish-catalog.yaml` rebuilds the catalog every 6 hours from every release currently in the public bucket, validates it with `stac-check-action`, then mirrors it to `stac.overturemaps.org` and busts the CloudFront cache.
+`publish-catalog.yaml` rebuilds the catalog every 6 hours from every release currently in the public bucket, validates it with `stac-check-action`, then mirrors it to `stac.overturemaps.org` and busts the CloudFront cache. See [`docs/architecture.md`](./docs/architecture.md) for how the publish step spans two AWS accounts and why.
 
 It also runs on manual dispatch, gated behind the `manual-publish` environment's required reviewer approval.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ![PyPI - Version](https://img.shields.io/pypi/v/overture-stac)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-This repo owns two things: `overture-stac`, the CLI that generates STAC catalogs for public Overture Maps releases, and the production catalog at `stac.overturemaps.org`, built and published by this repo's own GitHub Actions workflow.
+This repo owns two things: `overture-stac`, the CLI that generates STAC catalogs for public Overture releases, and the production catalog at `stac.overturemaps.org`, built and published by this repo's own GitHub Actions workflow.
 
 **[Browse the catalog](https://radiantearth.github.io/stac-browser/#/external/stac.overturemaps.org/catalog.json?.language=en)**
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,6 +2,16 @@
 
 `stac.overturemaps.org` used to come out of an Airflow DAG in `tf-data-platform`, `release_publish_stac_dag`, which meant the catalog's build logic lived in a different repo than the code that defined the catalog format. This repo is now self-contained: `publish-catalog.yaml` builds the catalog with this repo's own `overture-stac` CLI, validates it, and publishes it, all without leaving GitHub Actions.
 
+## Overall architecture
+
+```mermaid
+flowchart LR
+    A[gen-stac CLI] --> B[stac-check-action]
+    B --> C[(S3: distribution account)]
+    C --> D[CloudFront: core-data account]
+    D --> E[stac.overturemaps.org]
+```
+
 ## Data flow
 
 A run has three stages, always in this order:
@@ -19,14 +29,8 @@ The bucket that serves `stac.overturemaps.org` and the CloudFront distribution i
 - The distribution account owns `overturemaps-extras-us-west-2`, the S3 bucket the catalog is synced into under the `stac/` prefix.
 - The core-data account owns the CloudFront distribution that fronts `stac.overturemaps.org` and caches what's in that bucket.
 
-A single IAM role in one account can't reach into the other, so the workflow authenticates twice per publish: once to push the catalog to S3, once to bust the CDN cache.
-
-## OIDC and role chaining
-
-The workflow never holds long-lived AWS credentials. Each publish run starts by assuming `stac-publish-oidc-overturemaps` in the distribution account via GitHub's OIDC provider; that role's trust policy is scoped to this repo, keyed off `ref:refs/heads/main` for the scheduled trigger and `environment:manual-publish` for manual dispatch, so a fork or an unrelated branch can't assume it.
-
-Busting the CloudFront cache means getting into the core-data account from a role that only exists in the distribution account, which is where role chaining comes in: `configure-aws-credentials` is called a second time with `role-chaining: true`, using the credentials from the first assume-role to assume `cloudfront-invalidator` in the core-data account. That role's trust policy lists `stac-publish-oidc-overturemaps` as a principal, alongside the legacy `mwaa-executor` role left over from the Airflow DAG (tracked for removal once the DAG is decommissioned).
+A single IAM role in one account can't reach into the other, so the workflow assumes a role in each account in turn, chaining from the distribution account's role into the core-data account's, both via GitHub's OIDC provider rather than long-lived credentials.
 
 ## Triggers and gating
 
-`publish-catalog.yaml` runs on a `schedule` (every 6 hours) and on `workflow_dispatch`. Both triggers share one `publish` job; what differs is the job's `environment`, set via `${{ github.event_name == 'workflow_dispatch' && 'manual-publish' || '' }}`. An empty string evaluates to no environment, so the scheduled run publishes straight through, while a manual dispatch is gated behind the `manual-publish` environment's required reviewer approval. That's also the mechanism the OIDC trust policy keys off: the scheduled and manual paths present different claims to AWS, which is why the environment gate and the trust policy have to agree on the same environment name.
+`publish-catalog.yaml` runs on a `schedule` (every 6 hours) and on `workflow_dispatch`. Both triggers share one `publish` job; what differs is the job's `environment`, set via `${{ github.event_name == 'workflow_dispatch' && 'manual-publish' || '' }}`. An empty string evaluates to no environment, so the scheduled run publishes straight through, while a manual dispatch is gated behind the `manual-publish` environment's required reviewer approval.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -29,8 +29,6 @@ The bucket that serves `stac.overturemaps.org` and the CloudFront distribution i
 - The distribution account owns `overturemaps-extras-us-west-2`, the S3 bucket the catalog is synced into under the `stac/` prefix.
 - The core-data account owns the CloudFront distribution that fronts `stac.overturemaps.org` and caches what's in that bucket.
 
-A single IAM role in one account can't reach into the other, so the workflow assumes a role in each account in turn, chaining from the distribution account's role into the core-data account's, both via GitHub's OIDC provider rather than long-lived credentials.
-
 ## Triggers and gating
 
 `publish-catalog.yaml` runs on a `schedule` (every 6 hours) and on `workflow_dispatch`. Both triggers share one `publish` job; what differs is the job's `environment`, set via `${{ github.event_name == 'workflow_dispatch' && 'manual-publish' || '' }}`. An empty string evaluates to no environment, so the scheduled run publishes straight through, while a manual dispatch is gated behind the `manual-publish` environment's required reviewer approval.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -32,3 +32,13 @@ The bucket that serves `stac.overturemaps.org` and the CloudFront distribution i
 ## Triggers and gating
 
 `publish-catalog.yaml` runs on a `schedule` (every 6 hours) and on `workflow_dispatch`. Both triggers share one `publish` job; what differs is the job's `environment`, set via `${{ github.event_name == 'workflow_dispatch' && 'manual-publish' || '' }}`.
+
+## Slack notifications
+
+To get a Slack channel notified of publish runs, use GitHub's [Slack app](https://slack.github.com/) from that channel:
+
+```
+/github subscribe OvertureMaps/stac workflows:{"name":"Publish STAC Catalog"}
+```
+
+This is a one-time, per-channel setup step; it isn't configured by the workflow itself.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -31,4 +31,4 @@ The bucket that serves `stac.overturemaps.org` and the CloudFront distribution i
 
 ## Triggers and gating
 
-`publish-catalog.yaml` runs on a `schedule` (every 6 hours) and on `workflow_dispatch`. Both triggers share one `publish` job; what differs is the job's `environment`, set via `${{ github.event_name == 'workflow_dispatch' && 'manual-publish' || '' }}`. An empty string evaluates to no environment, so the scheduled run publishes straight through, while a manual dispatch is gated behind the `manual-publish` environment's required reviewer approval.
+`publish-catalog.yaml` runs on a `schedule` (every 6 hours) and on `workflow_dispatch`. Both triggers share one `publish` job; what differs is the job's `environment`, set via `${{ github.event_name == 'workflow_dispatch' && 'manual-publish' || '' }}`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -16,8 +16,8 @@ The build stage runs unauthenticated: it only reads public data and needs no AWS
 
 The bucket that serves `stac.overturemaps.org` and the CloudFront distribution in front of it live in different AWS accounts, split along Overture's existing account boundaries rather than anything specific to this workflow:
 
-- The distribution account (`913550007193`) owns `overturemaps-extras-us-west-2`, the S3 bucket the catalog is synced into under the `stac/` prefix.
-- The core-data account (`763944545891`) owns the CloudFront distribution ("Overture STAC Index", ID `E209PEWSOCNO5D`) that fronts `stac.overturemaps.org` and caches what's in that bucket.
+- The distribution account owns `overturemaps-extras-us-west-2`, the S3 bucket the catalog is synced into under the `stac/` prefix.
+- The core-data account owns the CloudFront distribution that fronts `stac.overturemaps.org` and caches what's in that bucket.
 
 A single IAM role in one account can't reach into the other, so the workflow authenticates twice per publish: once to push the catalog to S3, once to bust the CDN cache.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,32 @@
+# Publishing architecture
+
+`stac.overturemaps.org` used to come out of an Airflow DAG in `tf-data-platform`, `release_publish_stac_dag`, which meant the catalog's build logic lived in a different repo than the code that defined the catalog format. This repo is now self-contained: `publish-catalog.yaml` builds the catalog with this repo's own `overture-stac` CLI, validates it, and publishes it, all without leaving GitHub Actions.
+
+## Data flow
+
+A run has three stages, always in this order:
+
+1. `gen-stac --output public_releases` walks every release currently in the public registry bucket and writes the catalog to a working directory.
+2. `stac-check-action` validates the result against the STAC spec before anything gets published, using `fast-linting` for speed since this runs on the schedule.
+3. The validated catalog is synced to S3 and the CDN cache in front of it is invalidated.
+
+The build stage runs unauthenticated: it only reads public data and needs no AWS credentials. Publishing is where the workflow needs to touch two separate AWS accounts, which is the part worth understanding before changing anything here.
+
+## Why two AWS accounts
+
+The bucket that serves `stac.overturemaps.org` and the CloudFront distribution in front of it live in different AWS accounts, split along Overture's existing account boundaries rather than anything specific to this workflow:
+
+- The distribution account (`913550007193`) owns `overturemaps-extras-us-west-2`, the S3 bucket the catalog is synced into under the `stac/` prefix.
+- The core-data account (`763944545891`) owns the CloudFront distribution ("Overture STAC Index", ID `E209PEWSOCNO5D`) that fronts `stac.overturemaps.org` and caches what's in that bucket.
+
+A single IAM role in one account can't reach into the other, so the workflow authenticates twice per publish: once to push the catalog to S3, once to bust the CDN cache.
+
+## OIDC and role chaining
+
+The workflow never holds long-lived AWS credentials. Each publish run starts by assuming `stac-publish-oidc-overturemaps` in the distribution account via GitHub's OIDC provider; that role's trust policy is scoped to this repo, keyed off `ref:refs/heads/main` for the scheduled trigger and `environment:manual-publish` for manual dispatch, so a fork or an unrelated branch can't assume it.
+
+Busting the CloudFront cache means getting into the core-data account from a role that only exists in the distribution account, which is where role chaining comes in: `configure-aws-credentials` is called a second time with `role-chaining: true`, using the credentials from the first assume-role to assume `cloudfront-invalidator` in the core-data account. That role's trust policy lists `stac-publish-oidc-overturemaps` as a principal, alongside the legacy `mwaa-executor` role left over from the Airflow DAG (tracked for removal once the DAG is decommissioned).
+
+## Triggers and gating
+
+`publish-catalog.yaml` runs on a `schedule` (every 6 hours) and on `workflow_dispatch`. Both triggers share one `publish` job; what differs is the job's `environment`, set via `${{ github.event_name == 'workflow_dispatch' && 'manual-publish' || '' }}`. An empty string evaluates to no environment, so the scheduled run publishes straight through, while a manual dispatch is gated behind the `manual-publish` environment's required reviewer approval. That's also the mechanism the OIDC trust policy keys off: the scheduled and manual paths present different claims to AWS, which is why the environment gate and the trust policy have to agree on the same environment name.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Publishing architecture
 
-`stac.overturemaps.org` used to come out of an Airflow DAG in `tf-data-platform`, `release_publish_stac_dag`, which meant the catalog's build logic lived in a different repo than the code that defined the catalog format. This repo is now self-contained: `publish-catalog.yaml` builds the catalog with this repo's own `overture-stac` CLI, validates it, and publishes it, all without leaving GitHub Actions.
+`publish-catalog.yaml` builds the production STAC catalog with this repo's own `overture-stac` CLI, validates it, and publishes it to `stac.overturemaps.org`, all without leaving GitHub Actions.
 
 ## Overall architecture
 


### PR DESCRIPTION
Adds `publish-catalog.yaml`: rebuilds the catalog every 6 hours with `gen-stac`, validates it with `stac-check-action`, mirrors it to `overturemaps-extras-us-west-2/stac/` via the `s5cmd` action in OvertureMaps/workflows, then busts the CloudFront cache. Replaces tf-data-platform's `release_publish_stac_dag`.

One `publish` job handles both the scheduled and manual triggers, with `environment: ${{ github.event_name == 'workflow_dispatch' && 'manual-publish' || '' }}`. An empty string means no environment, which GitHub Actions treats as "no environment protection rules," not an error, so the scheduled run isn't gated and the manual dispatch goes through the `manual-publish` environment's reviewer approval.

CloudFront invalidation is cross-account (distribution account → core-data account), so it's a second `configure-aws-credentials` step with `role-chaining: true`, assuming `cloudfront-invalidator` from the already-assumed S3 role. That role's trust policy picked up the new principal in OvertureMaps/omf-core-data-opentofu#97.

Role ARNs, the CloudFront distribution ID, the catalog output dir, and the AWS region all live in the workflow's top-level `env:` block instead of being repeated inline. Role ARNs and the distribution ID are pulled from the already-merged/in-review companion PRs on the sub-issues (#96, #120), not guessed.

Also:
- Adds a status badge for the new workflow to the README, and splits the README so the PyPI-rendered package docs stay package-focused; the publishing pipeline detail moved to `docs/architecture.md` (with a mermaid diagram of the S3 → CloudFront → `stac.overturemaps.org` flow).
- Documents the one-time, per-channel Slack subscription command (`/github subscribe ... workflows:{"name":"Publish STAC Catalog"}`) in `docs/architecture.md` — this isn't something the workflow configures itself.

Not yet in scope (tracked separately): OvertureMaps/stac#109 (skip the rebuild when the release bucket hasn't changed) and OvertureMaps/tf-data-platform#4875 (pause/decommission the old DAG once this has run clean in prod).

Untested end-to-end: the AWS side depends on OvertureMaps/omf-core-data-opentofu#97, OvertureMaps/omf-distribution-account-opentofu#14, and OvertureMaps/omf-github-terraform#121 all landing first, so I haven't been able to run this against real credentials yet.

Closes #107.