### PR TITLE
[CHORE] Bump stac-check-action, drop pre-publish validation pending theme fan-out

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -134,13 +134,27 @@ jobs:
             sleep 0.5
           done
 
-      - name: Validate root catalog
+      # TEMP: A/B timing comparison for OvertureMaps/stac#112. Runs validation twice,
+      # once with the current fast-linting mode and once with fast (skips linting
+      # too), so this PR's CI run gives us real numbers before switching the
+      # publish-catalog.yaml gate over. Remove the fast-linting step once we've
+      # measured a few runs.
+      - name: Validate root catalog (fast-linting, baseline)
         uses: OvertureMaps/stac-check-action@71e219583b4fd87f797bac5840b088c048116765 # v1.1.0
         with:
           stac-check-version: "1.14.0"
           file: http://127.0.0.1:8888/catalog.json
           recursive: "true"
           fast-linting: "true"
+          job-summary: "true"
+
+      - name: Validate root catalog (fast, candidate)
+        uses: OvertureMaps/stac-check-action@71e219583b4fd87f797bac5840b088c048116765 # v1.1.0
+        with:
+          stac-check-version: "1.14.0"
+          file: http://127.0.0.1:8888/catalog.json
+          recursive: "true"
+          fast: "true"
           job-summary: "true"
 
       - name: Stop local server

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -134,31 +134,13 @@ jobs:
             sleep 0.5
           done
 
-      # TEMP: A/B timing comparison for OvertureMaps/stac#112. Runs validation twice,
-      # once with the current fast-linting mode and once with fast (skips linting
-      # too), so this PR's CI run gives us real numbers before switching the
-      # publish-catalog.yaml gate over. Remove the fast-linting step once we've
-      # measured a few runs.
-      - name: Validate root catalog (fast-linting, baseline)
-        if: always()
-        timeout-minutes: 10
+      - name: Validate root catalog
         uses: OvertureMaps/stac-check-action@71e219583b4fd87f797bac5840b088c048116765 # v1.1.0
         with:
           stac-check-version: "1.14.0"
           file: http://127.0.0.1:8888/catalog.json
           recursive: "true"
           fast-linting: "true"
-          job-summary: "true"
-
-      - name: Validate root catalog (fast, candidate)
-        if: always()
-        timeout-minutes: 10
-        uses: OvertureMaps/stac-check-action@71e219583b4fd87f797bac5840b088c048116765 # v1.1.0
-        with:
-          stac-check-version: "1.14.0"
-          file: http://127.0.0.1:8888/catalog.json
-          recursive: "true"
-          fast: "true"
           job-summary: "true"
 
       - name: Stop local server

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -140,6 +140,8 @@ jobs:
       # publish-catalog.yaml gate over. Remove the fast-linting step once we've
       # measured a few runs.
       - name: Validate root catalog (fast-linting, baseline)
+        if: always()
+        timeout-minutes: 10
         uses: OvertureMaps/stac-check-action@71e219583b4fd87f797bac5840b088c048116765 # v1.1.0
         with:
           stac-check-version: "1.14.0"
@@ -149,6 +151,8 @@ jobs:
           job-summary: "true"
 
       - name: Validate root catalog (fast, candidate)
+        if: always()
+        timeout-minutes: 10
         uses: OvertureMaps/stac-check-action@71e219583b4fd87f797bac5840b088c048116765 # v1.1.0
         with:
           stac-check-version: "1.14.0"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -135,7 +135,7 @@ jobs:
           done
 
       - name: Validate root catalog
-        uses: OvertureMaps/stac-check-action@3b06576bbf96c8d172f627c1639ac128f4fd7e38 # v1.0.0
+        uses: OvertureMaps/stac-check-action@71e219583b4fd87f797bac5840b088c048116765 # v1.1.0
         with:
           stac-check-version: "1.14.0"
           file: http://127.0.0.1:8888/catalog.json

--- a/.github/workflows/publish-catalog.yaml
+++ b/.github/workflows/publish-catalog.yaml
@@ -50,13 +50,26 @@ jobs:
       - name: Build STAC Catalog
         run: gen-stac --output "$CATALOG_OUTPUT_DIR"
 
-      - name: Validate STAC Catalog
-        uses: OvertureMaps/stac-check-action@3b06576bbf96c8d172f627c1639ac128f4fd7e38 # v1.0.0
+      # TEMP: A/B timing comparison. Runs validation twice, once with the current
+      # fast-linting mode and once with fast (skips linting too), so we can compare
+      # job duration before switching over. Remove the fast-linting step once we've
+      # collected a few scheduled runs' worth of timings.
+      - name: Validate STAC Catalog (fast-linting, baseline)
+        uses: OvertureMaps/stac-check-action@71e219583b4fd87f797bac5840b088c048116765 # v1.1.0
         with:
           stac-check-version: "1.14.0"
           file: ${{ env.CATALOG_OUTPUT_DIR }}/catalog.json
           recursive: "true"
           fast-linting: "true"
+          job-summary: "true"
+
+      - name: Validate STAC Catalog (fast, candidate)
+        uses: OvertureMaps/stac-check-action@71e219583b4fd87f797bac5840b088c048116765 # v1.1.0
+        with:
+          stac-check-version: "1.14.0"
+          file: ${{ env.CATALOG_OUTPUT_DIR }}/catalog.json
+          recursive: "true"
+          fast: "true"
           job-summary: "true"
 
       - name: Upload artifact

--- a/.github/workflows/publish-catalog.yaml
+++ b/.github/workflows/publish-catalog.yaml
@@ -8,6 +8,11 @@ on:
   schedule:
     - cron: "0 */6 * * *" # every 6 hours
   workflow_dispatch:
+    inputs:
+      publish:
+        description: "Actually publish to S3/CloudFront (leave unchecked for dry runs, e.g. A/B timing tests)"
+        type: boolean
+        default: false
 
 permissions: {}
 
@@ -86,6 +91,10 @@ jobs:
     name: Publish
     runs-on: ubuntu-latest
     needs: build
+    # Scheduled runs always publish. Manual dispatches only publish if the `publish`
+    # input is explicitly checked, so a dry run (e.g. A/B timing tests) never creates
+    # a pending manual-publish approval in the first place.
+    if: ${{ github.event_name == 'schedule' || inputs.publish == true }}
     # Empty string evaluates to "no environment" for a job-level `environment:`,
     # so the schedule trigger skips the manual-publish gate entirely.
     environment: ${{ github.event_name == 'workflow_dispatch' && 'manual-publish' || '' }} # manual-publish requires reviewer approval

--- a/.github/workflows/publish-catalog.yaml
+++ b/.github/workflows/publish-catalog.yaml
@@ -50,13 +50,30 @@ jobs:
       - name: Build STAC Catalog
         run: gen-stac --output "$CATALOG_OUTPUT_DIR"
 
-      - name: Validate STAC Catalog
+      # TEMP: A/B timing comparison for OvertureMaps/stac#112. Runs validation twice
+      # against the real, full-scale production catalog straight off disk (no debug
+      # limit, no local HTTP server), so the numbers match what actually runs during
+      # a publish. Remove the fast-linting step once we've measured a real run.
+      - name: Validate STAC Catalog (fast-linting, baseline)
+        if: always()
+        timeout-minutes: 30
         uses: OvertureMaps/stac-check-action@71e219583b4fd87f797bac5840b088c048116765 # v1.1.0
         with:
           stac-check-version: "1.14.0"
           file: ${{ env.CATALOG_OUTPUT_DIR }}/catalog.json
           recursive: "true"
           fast-linting: "true"
+          job-summary: "true"
+
+      - name: Validate STAC Catalog (fast, candidate)
+        if: always()
+        timeout-minutes: 30
+        uses: OvertureMaps/stac-check-action@71e219583b4fd87f797bac5840b088c048116765 # v1.1.0
+        with:
+          stac-check-version: "1.14.0"
+          file: ${{ env.CATALOG_OUTPUT_DIR }}/catalog.json
+          recursive: "true"
+          fast: "true"
           job-summary: "true"
 
       - name: Upload artifact

--- a/.github/workflows/publish-catalog.yaml
+++ b/.github/workflows/publish-catalog.yaml
@@ -29,7 +29,7 @@ env:
 
 jobs:
   build:
-    name: Build & Validate
+    name: Build Catalog
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -55,42 +55,55 @@ jobs:
       - name: Build STAC Catalog
         run: gen-stac --output "$CATALOG_OUTPUT_DIR"
 
-      # TEMP: A/B timing comparison for OvertureMaps/stac#112. Runs validation twice
-      # against the real, full-scale production catalog straight off disk (no debug
-      # limit, no local HTTP server), so the numbers match what actually runs during
-      # a publish. Remove the fast-linting step once we've measured a real run.
-      - name: Validate STAC Catalog (fast-linting, baseline)
-        if: always()
-        timeout-minutes: 30
-        uses: OvertureMaps/stac-check-action@71e219583b4fd87f797bac5840b088c048116765 # v1.1.0
-        with:
-          stac-check-version: "1.14.0"
-          file: ${{ env.CATALOG_OUTPUT_DIR }}/catalog.json
-          recursive: "true"
-          fast-linting: "true"
-          job-summary: "true"
-
-      - name: Validate STAC Catalog (fast, candidate)
-        if: always()
-        timeout-minutes: 30
-        uses: OvertureMaps/stac-check-action@71e219583b4fd87f797bac5840b088c048116765 # v1.1.0
-        with:
-          stac-check-version: "1.14.0"
-          file: ${{ env.CATALOG_OUTPUT_DIR }}/catalog.json
-          recursive: "true"
-          fast: "true"
-          job-summary: "true"
-
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: stac-catalog
           path: ${{ env.CATALOG_OUTPUT_DIR }}
 
+  # TEMP: A/B timing comparison for OvertureMaps/stac#112. Matrix runs fast-linting
+  # and fast in parallel jobs (not sequential steps) against the real, full-scale
+  # production catalog straight off disk, so the numbers match what actually runs
+  # during a publish without doubling the wall-clock wait. Delete this job and point
+  # `publish.needs` back at `build` once we've measured a real run.
+  validate:
+    name: Validate STAC Catalog (${{ matrix.name }})
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      actions: read # required for actions/download-artifact
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: fast-linting, baseline
+            fast-linting: "true"
+            fast: "false"
+          - name: fast, candidate
+            fast-linting: "false"
+            fast: "true"
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: stac-catalog
+          path: ${{ env.CATALOG_OUTPUT_DIR }}
+
+      - name: Validate STAC Catalog
+        timeout-minutes: 30
+        uses: OvertureMaps/stac-check-action@71e219583b4fd87f797bac5840b088c048116765 # v1.1.0
+        with:
+          stac-check-version: "1.14.0"
+          file: ${{ env.CATALOG_OUTPUT_DIR }}/catalog.json
+          recursive: "true"
+          fast-linting: ${{ matrix.fast-linting }}
+          fast: ${{ matrix.fast }}
+          job-summary: "true"
+
   publish:
     name: Publish
     runs-on: ubuntu-latest
-    needs: build
+    needs: validate
     # Scheduled runs always publish. Manual dispatches only publish if the `publish`
     # input is explicitly checked, so a dry run (e.g. A/B timing tests) never creates
     # a pending manual-publish approval in the first place.

--- a/.github/workflows/publish-catalog.yaml
+++ b/.github/workflows/publish-catalog.yaml
@@ -1,7 +1,16 @@
 ---
 # Publishes the production STAC catalog (stac.overturemaps.org). Rebuilds the
-# catalog for every release currently in the public bucket, validates it, then
-# mirrors it to the public S3 bucket and busts the CloudFront cache.
+# catalog for every release currently in the public bucket, then mirrors it to the
+# public S3 bucket and busts the CloudFront cache.
+#
+# No pre-publish validation runs here: recursive stac-check validation of the real
+# production catalog (root -> release -> theme -> type -> item) doesn't finish in a
+# reasonable time single-threaded, an A/B timing run against it ran past 19 minutes
+# per mode before being cancelled. ci.yaml's stac-validate job already exercises the
+# same build_root_catalog/build_release_catalog code on every push and PR to main, so
+# catalogs generated from main are trusted without a second, much slower check here.
+# Tracked in OvertureMaps/stac#112: reintroduce validation once it's fanned out
+# per-theme so it's fast enough not to block the publish gate.
 name: Publish STAC Catalog
 
 on:
@@ -10,7 +19,7 @@ on:
   workflow_dispatch:
     inputs:
       publish:
-        description: "Actually publish to S3/CloudFront (leave unchecked for dry runs, e.g. A/B timing tests)"
+        description: "Actually publish to S3/CloudFront (leave unchecked for build-only dry runs)"
         type: boolean
         default: false
 
@@ -61,52 +70,13 @@ jobs:
           name: stac-catalog
           path: ${{ env.CATALOG_OUTPUT_DIR }}
 
-  # TEMP: A/B timing comparison for OvertureMaps/stac#112. Matrix runs fast-linting
-  # and fast in parallel jobs (not sequential steps) against the real, full-scale
-  # production catalog straight off disk, so the numbers match what actually runs
-  # during a publish without doubling the wall-clock wait. Delete this job and point
-  # `publish.needs` back at `build` once we've measured a real run.
-  validate:
-    name: Validate STAC Catalog (${{ matrix.name }})
-    runs-on: ubuntu-latest
-    needs: build
-    permissions:
-      actions: read # required for actions/download-artifact
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: fast-linting, baseline
-            fast-linting: "true"
-            fast: "false"
-          - name: fast, candidate
-            fast-linting: "false"
-            fast: "true"
-    steps:
-      - name: Download artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: stac-catalog
-          path: ${{ env.CATALOG_OUTPUT_DIR }}
-
-      - name: Validate STAC Catalog
-        timeout-minutes: 30
-        uses: OvertureMaps/stac-check-action@71e219583b4fd87f797bac5840b088c048116765 # v1.1.0
-        with:
-          stac-check-version: "1.14.0"
-          file: ${{ env.CATALOG_OUTPUT_DIR }}/catalog.json
-          recursive: "true"
-          fast-linting: ${{ matrix.fast-linting }}
-          fast: ${{ matrix.fast }}
-          job-summary: "true"
-
   publish:
     name: Publish
     runs-on: ubuntu-latest
-    needs: validate
+    needs: build
     # Scheduled runs always publish. Manual dispatches only publish if the `publish`
-    # input is explicitly checked, so a dry run (e.g. A/B timing tests) never creates
-    # a pending manual-publish approval in the first place.
+    # input is explicitly checked, so a build-only dry run never creates a pending
+    # manual-publish approval in the first place.
     if: ${{ github.event_name == 'schedule' || inputs.publish == true }}
     # Empty string evaluates to "no environment" for a job-level `environment:`,
     # so the schedule trigger skips the manual-publish gate entirely.

--- a/.github/workflows/publish-catalog.yaml
+++ b/.github/workflows/publish-catalog.yaml
@@ -50,26 +50,13 @@ jobs:
       - name: Build STAC Catalog
         run: gen-stac --output "$CATALOG_OUTPUT_DIR"
 
-      # TEMP: A/B timing comparison. Runs validation twice, once with the current
-      # fast-linting mode and once with fast (skips linting too), so we can compare
-      # job duration before switching over. Remove the fast-linting step once we've
-      # collected a few scheduled runs' worth of timings.
-      - name: Validate STAC Catalog (fast-linting, baseline)
+      - name: Validate STAC Catalog
         uses: OvertureMaps/stac-check-action@71e219583b4fd87f797bac5840b088c048116765 # v1.1.0
         with:
           stac-check-version: "1.14.0"
           file: ${{ env.CATALOG_OUTPUT_DIR }}/catalog.json
           recursive: "true"
           fast-linting: "true"
-          job-summary: "true"
-
-      - name: Validate STAC Catalog (fast, candidate)
-        uses: OvertureMaps/stac-check-action@71e219583b4fd87f797bac5840b088c048116765 # v1.1.0
-        with:
-          stac-check-version: "1.14.0"
-          file: ${{ env.CATALOG_OUTPUT_DIR }}/catalog.json
-          recursive: "true"
-          fast: "true"
           job-summary: "true"
 
       - name: Upload artifact


### PR DESCRIPTION
Closes #112.

Bumps `OvertureMaps/stac-check-action` from `v1.0.0` to `v1.1.0` in `ci.yaml`. v1.1.0 streams `stac-check` output live instead of buffering it until exit (OvertureMaps/stac-check-action#11).

Started out as a proposal to switch `publish-catalog.yaml`'s validate step from `fast-linting: "true"` to `fast: "true"` for a scheduled publish gate, A/B'd with real timing runs before committing to the switch. A manual `workflow_dispatch` dry run against the real production catalog (not the debug-mode fixture `ci.yaml` uses) showed both modes still recursively validating past 19 minutes when cancelled: single-threaded recursive `stac-check` doesn't scale to Overture's full catalog size regardless of which mode we pick.

`publish-catalog.yaml`'s validate step was net-new (added in #110, this is its first run at production scale), so rather than ship a publish gate that may never finish, this drops it entirely. `ci.yaml`'s `stac-validate` job already exercises `build_root_catalog`/`build_release_catalog` on every push and PR to main, so catalogs generated from main are trusted without a second, much slower check at publish time.

> [!NOTE]
> A sibling investigation (OvertureMaps/stac-check-action, branch `lowlydba-stac-check-perf`) measured why: `stac-check --recursive` validates one node at a time and rebuilds `jsonschema`'s `Registry` from scratch per node. A synthetic 1000-item catalog took 80s single-threaded vs. 16.3s split into 10 sub-catalogs run 4-way parallel (4.9x). The fix belongs in this workflow as a theme-level matrix fan-out (root → release → theme → type → item, themes are the natural fan-out boundary), not in `stac-check-action` itself, which stays generic. Tracked as a follow-up on #112.

Also added a `publish` boolean input (default `false`) to `workflow_dispatch` so manual test dispatches build without ever creating a pending `manual-publish` approval, that's how the timing dry run above was able to run safely.
