### PR TITLE
[BUG] Skip session tagging on cloudfront-invalidator assume-role

### DIFF
--- a/.github/workflows/publish-catalog.yaml
+++ b/.github/workflows/publish-catalog.yaml
@@ -98,7 +98,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Sync to S3
-        uses: OvertureMaps/workflows/.github/actions/s5cmd@1e394d3cfcdc529069e9abe8643c3288ea940a52 # TEMP: OvertureMaps/workflows#84 e2e verification, revert to @main before merge
+        uses: OvertureMaps/workflows/.github/actions/s5cmd@main # zizmor: ignore[unpinned-uses] intentionally track main
         with:
           command: sync
           flags: --delete

--- a/.github/workflows/publish-catalog.yaml
+++ b/.github/workflows/publish-catalog.yaml
@@ -110,6 +110,7 @@ jobs:
         with:
           role-to-assume: ${{ env.CLOUDFRONT_INVALIDATOR_ROLE_ARN }}
           role-chaining: true
+          role-skip-session-tagging: true # stac-publish-oidc-overturemaps lacks sts:TagSession on cloudfront-invalidator; nothing consumes session tags here
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Bust the cache

--- a/.github/workflows/publish-catalog.yaml
+++ b/.github/workflows/publish-catalog.yaml
@@ -98,7 +98,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Sync to S3
-        uses: OvertureMaps/workflows/.github/actions/s5cmd@main # zizmor: ignore[unpinned-uses] intentionally track main
+        uses: OvertureMaps/workflows/.github/actions/s5cmd@1e394d3cfcdc529069e9abe8643c3288ea940a52 # TEMP: OvertureMaps/workflows#84 e2e verification, revert to @main before merge
         with:
           command: sync
           flags: --delete


### PR DESCRIPTION
## What's broken

The `Publish` job's `Configure AWS credentials (CloudFront invalidation, cross-account)` step fails every time, so `Bust the cache` never runs:

```
Retry AssumeRole: attempt 1 of 12 failed: Could not assume role with user credentials: User:
arn:aws:sts::913550007193:assumed-role/stac-publish-oidc-overturemaps/GitHubActions is not authorized to perform:
sts:TagSession on resource: arn:aws:iam::763944545891:role/cloudfront-invalidator
```

Run: https://github.com/OvertureMaps/stac/actions/runs/32196096191/job/95900914357

`aws-actions/configure-aws-credentials` tags the session by default on every `AssumeRole` call. `stac-publish-oidc-overturemaps` has no `sts:TagSession` permission on `cloudfront-invalidator`. Checked both `cloudfront-invalidator`'s trust policy and its `AllowInvalidate` policy in `omf-core-data-opentofu/cloudfront.tf`: neither reads `aws:PrincipalTag` or any session tag, so there's nothing here that actually needs the tag. Setting `role-skip-session-tagging: true` on that step is simpler than granting the permission for a tag nobody reads.

Fixes #113

## Testing

Confirmed end-to-end via `workflow_dispatch` with `publish: true`: before this change, `Configure AWS credentials (CloudFront invalidation, cross-account)` failed with the `sts:TagSession` error above after the retry budget was exhausted; after adding `role-skip-session-tagging: true`, that step and `Bust the cache` both succeeded.
