### PR TITLE
[BUG] Fix --delete flag placement in s5cmd sync step

### DIFF
--- a/.github/workflows/publish-catalog.yaml
+++ b/.github/workflows/publish-catalog.yaml
@@ -101,7 +101,7 @@ jobs:
         uses: OvertureMaps/workflows/.github/actions/s5cmd@main # zizmor: ignore[unpinned-uses] intentionally track main
         with:
           command: sync
-          flags: --delete
+          subcommand-flags: --delete
           source: ${{ env.CATALOG_OUTPUT_DIR }}/
           destination: s3://overturemaps-extras-us-west-2/stac/
 


### PR DESCRIPTION
The `Sync to S3` step in `publish-catalog.yaml` passed `--delete` via the `flags` input of `OvertureMaps/workflows/.github/actions/s5cmd@main`, which is for global flags. `--delete` is a `sync` subcommand flag, so the action auto-corrected it and warned on every run:

https://github.com/OvertureMaps/stac/actions/runs/32281831164

```
'--delete' is a sync-subcommand flag, not a global one; moving it after 'sync' automatically. Pass it via 'subcommand-flags' instead of 'flags' to avoid this warning.
```

Moves `--delete` to `subcommand-flags`, matching how the action expects it.

Fixes #117

Not tested against a real S3 publish, this only changes which input the flag flows through and the action's own validation confirms the corrected placement is what it expects.