### PR TITLE
[FEATURE] add providers, keywords, human titles, and column types

### DIFF
--- a/src/overture_stac/overture_stac.py
+++ b/src/overture_stac/overture_stac.py
@@ -125,6 +125,45 @@ TYPE_LICENSE_MAP: dict[str, str] = {
     "address": "other",
 }
 
+# Human-readable collection titles. Raw type slugs ("land_cover") render as-is
+# in STAC browsers, which reads as an unfinished catalog.
+TYPE_TITLE_MAP: dict[str, str] = {
+    "bathymetry": "Bathymetry",
+    "land_cover": "Land Cover",
+    "infrastructure": "Infrastructure",
+    "land": "Land",
+    "land_use": "Land Use",
+    "water": "Water",
+    "building": "Buildings",
+    "building_part": "Building Parts",
+    "division": "Divisions",
+    "division_area": "Division Areas",
+    "division_boundary": "Division Boundaries",
+    "segment": "Transportation Segments",
+    "connector": "Transportation Connectors",
+    "place": "Places",
+    "address": "Addresses",
+}
+
+PROVIDERS: list[pystac.Provider] = [
+    pystac.Provider(
+        name="Overture Maps Foundation",
+        description=(
+            "Overture Maps Foundation is a collaborative effort of its members to "
+            "build open, interoperable map data. It assembles, conflates, and "
+            "quality-checks the source datasets behind this collection and "
+            "publishes them on a monthly cadence."
+        ),
+        roles=[
+            pystac.ProviderRole.PRODUCER,
+            pystac.ProviderRole.LICENSOR,
+            pystac.ProviderRole.PROCESSOR,
+            pystac.ProviderRole.HOST,
+        ],
+        url="https://overturemaps.org/",
+    )
+]
+
 
 def process_theme_worker(
     theme_path: str,
@@ -324,8 +363,10 @@ def process_theme_worker(
         # Create type collection
         type_collection = pystac.Collection(
             id=type_name,
-            title=type_name,
+            title=TYPE_TITLE_MAP.get(type_name, type_name),
             description=f"Overture's {type_name} collection",
+            providers=PROVIDERS,
+            keywords=["overture", theme_name, type_name],
             extent=pystac.Extent(
                 spatial=pystac.SpatialExtent(
                     bboxes=[i.bbox for i in local_type_collections[type_name]]
@@ -347,6 +388,16 @@ def process_theme_worker(
 
         type_collection.add_items(local_type_collections[type_name])
 
+        # Item links carry no title by default, which STAC best practice and the
+        # Portolan profile both flag. Name each after the partition it points at.
+        item_title = TYPE_TITLE_MAP.get(type_name, type_name)
+        for link in type_collection.get_links(rel="item"):
+            # Links still hold the Item object at this point; hrefs are not
+            # assigned until the catalog is normalized, so read the id.
+            target = link.target
+            if link.title is None and isinstance(target, pystac.Item):
+                link.title = f"{item_title} partition {target.id}"
+
         items = local_type_collections[type_name]
         if items:
             row_counts = [i.properties["num_rows"] for i in items]
@@ -367,7 +418,12 @@ def process_theme_worker(
         ]
         type_collection.extra_fields = {
             "table:columns": (
-                [{"name": name} for name in schema.names] if schema is not None else []
+                [
+                    {"name": name, "type": str(dtype)}
+                    for name, dtype in zip(schema.names, schema.types, strict=True)
+                ]
+                if schema is not None
+                else []
             ),
             "table:primary_geometry": "geometry",
             "table:row_count": total_row_count,

--- a/src/overture_stac/overture_stac.py
+++ b/src/overture_stac/overture_stac.py
@@ -154,8 +154,14 @@ PROVIDERS: list[pystac.Provider] = [
             "quality-checks the source datasets behind this collection and "
             "publishes them on a monthly cadence."
         ),
+        # No "producer" role. STAC defines a producer as the party that
+        # initially captured the source data, which for Overture is the
+        # upstream sources (OpenStreetMap, Esri, Google, Microsoft and
+        # others), not the foundation that conflates them. Modelling those
+        # properly needs a per-theme provider list, since the source mix
+        # differs by theme; the per-feature `sources` column already
+        # records it exactly. See #TODO.
         roles=[
-            pystac.ProviderRole.PRODUCER,
             pystac.ProviderRole.LICENSOR,
             pystac.ProviderRole.PROCESSOR,
             pystac.ProviderRole.HOST,

--- a/src/overture_stac/overture_stac.py
+++ b/src/overture_stac/overture_stac.py
@@ -160,7 +160,7 @@ PROVIDERS: list[pystac.Provider] = [
         # others), not the foundation that conflates them. Modelling those
         # properly needs a per-theme provider list, since the source mix
         # differs by theme; the per-feature `sources` column already
-        # records it exactly. See #TODO.
+        # records it exactly. See #124.
         roles=[
             pystac.ProviderRole.LICENSOR,
             pystac.ProviderRole.PROCESSOR,

--- a/tests/test_process_theme_worker.py
+++ b/tests/test_process_theme_worker.py
@@ -33,6 +33,7 @@ def make_mock_fragment(path: str, num_rows: int = 100, num_row_groups: int = 2):
     schema = MagicMock()
     schema.metadata = {b"geo": geo_metadata}
     schema.names = ["id", "geometry", "name"]
+    schema.types = ["string", "binary", "string"]
 
     metadata = MagicMock()
     metadata.num_rows = num_rows
@@ -197,9 +198,9 @@ class TestProcessThemeWorker:
         extra = collection.extra_fields
 
         assert extra["table:columns"] == [
-            {"name": "id"},
-            {"name": "geometry"},
-            {"name": "name"},
+            {"name": "id", "type": "string"},
+            {"name": "geometry", "type": "binary"},
+            {"name": "name", "type": "string"},
         ]
         assert extra["table:primary_geometry"] == "geometry"
         assert extra["table:row_count"] == 3000
@@ -440,7 +441,7 @@ class TestProcessThemeWorker:
         # Verify collection has a title
         collections = list(theme_catalog.get_children())
         assert collections[0].title is not None
-        assert collections[0].title == "place"
+        assert collections[0].title == "Places"
 
 
 class TestBuildReleaseCatalog:

--- a/uv.lock
+++ b/uv.lock
@@ -310,7 +310,7 @@ wheels = [
 
 [[package]]
 name = "overture-stac"
-version = "1.3.0"
+version = "1.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "pyarrow" },


### PR DESCRIPTION
#### What

This PR makes improvements to the collection-level STAC metadata. It closes #122.

| | Before | After |
|---|---|---|
| Collection `title` | `land_cover` | `Land Cover` |
| `providers` | absent | Overture Maps Foundation — licensor, processor, host |
| `keywords` | absent | `["overture", "base", "land_cover"]` |
| `table:columns` entry | `{"name": "confidence"}` | `{"name": "confidence", "type": "double"}` |
| Item link `title` | absent | `Places partition 00000` |

Collection `id` is untouched, so nothing that addresses collections by id is affected — only the display title changes.

#### Why

Two of these are already flagged by tooling we run. `stac-check` reports "Links in catalogs and collections should always have a 'title' field" against every collection in the catalog today; after this it reports nothing.

The `table:columns` gap is the one consumers notice. There are 217 column entries across the 15 collections in `2026-08-19.0`, and every one carries a bare name — so anyone working out whether `confidence` is a float or a string has to go open a Parquet file. The type is available from the Arrow schema `process_theme_worker` already reads for the bbox, so filling it in costs nothing.

`providers` is the STAC field that answers "who made this", and the catalog currently doesn't answer it anywhere.

#### Evidence

`stac-check` on a generated collection:

```
before:  STAC Best Practices:
           Links in catalogs and collections should always have a 'title' field
after:   STAC Best Practices:
           (none)
```

Also measured against `rashid` 0.1.8 — the validator for the Portolan profile, a stricter STAC profile we've been evaluating separately. Same debug-mode catalog, generator at HEAD versus this branch: **179 errors → 142**.

| Rule | Before | After |
|---|---|---|
| every child and item link must include a title | 37 | 0 |
| titles must be human-readable, not raw slugs | 5 | 0 |
| every collection needs at least one provider with the producer role | 15 | 15 — deliberately, see below |

Nothing here depends on that profile and it isn't adopted by this PR — it's just a convenient second opinion.

#### Testing

```bash
uv run pytest -q                            # 32 unit tests
uv run python tests/setup_test_catalog.py   # builds a debug catalog against S3
uv run pytest -q                            # 62 tests, e2e included
```

All 62 pass. Two existing assertions in `tests/test_process_theme_worker.py` encoded the old behaviour (`title == "place"`, and `table:columns` without types) and were updated; the mock schema helper gained a `types` attribute to match `pyarrow.Schema`.

One implementation note worth a reviewer's eye: item link titles derive from `link.target.id` rather than the href, because pystac links still hold the `Item` object at that point and `link.href` raises until the catalog is normalized.

#### Why there is no `producer` role

The provider entry carries `licensor`, `processor`, and `host`, but deliberately not `producer`.

STAC defines a producer as the party that *initially captured and processed the source data* — the spec's example is ESA for Sentinel-2. For Overture that's the upstream sources: OpenStreetMap contributors, Esri Community Maps, Google Open Buildings, Microsoft ML Building Footprints. Not the foundation, which assembles and conflates what they captured.

Adding `producer: Overture Maps Foundation` would have satisfied `rashid`'s `PTL-PRV-001` and every other check that expects one, but it would credit OMF for capture work it didn't do and leave the catalog silent about the organizations whose data it redistributes. Given several of those licenses carry attribution requirements, that felt like the wrong thing to paper over for a green check.

Doing it properly needs a per-theme provider list — buildings draws on sources places doesn't — verified by whoever owns attribution. Follow-up issue: TODO.

#### A note on the titles

Five of the fifteen were raw slugs with underscores (`land_cover`, `land_use`, `building_part`, `division_area`, `division_boundary`) and are unambiguous fixes. The rest involved some judgement: collections are pluralized where that reads naturally (`building` → `Buildings`) but not where it doesn't (`land` stays `Land`), and `segment` / `connector` became `Transportation Segments` / `Transportation Connectors` because those words are vague standing alone in a browser list. Happy to trim that back to just the five if reviewers would rather avoid the editorializing.

#### Not in this PR

- **Collection `bbox[0]`** (#121) — assigned to @jjcfrancisco. This PR doesn't touch extent construction, though it edits the adjacent `pystac.Collection(...)` arguments, so expect a small conflict if both land close together.
- **Item bboxes outside WGS84.** Four items in `base/land_cover` carry longitudes about 0.00023° past ±180 (~25 m). The generator reads these faithfully from the GeoParquet `geo` metadata, so the fix likely belongs upstream with the land_cover data rather than as a clamp here. Not yet filed.
- **Collection descriptions.** Still `Overture's <type> collection`. Writing real ones needs per-theme research and deserves its own issue.

#### Note on the Rust port

#119 replaces `src/overture_stac/overture_stac.py` with a Rust implementation, and `src/stac/theme.rs` on the `rust` branch reproduces all five of these gaps. Whichever implementation these land in, the other needs the same change.
